### PR TITLE
[TR1L-36] chore: PR merge 차단 해제를 위한 gradle 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ jacocoTestReport {
         csv.required = false
     }
 
-    finalizedBy 'jacocoTestCoverageVerification'
+    //finalizedBy 'jacocoTestCoverageVerification'
 }
 
 jacocoTestCoverageVerification {
@@ -76,7 +76,7 @@ jacocoTestCoverageVerification {
 }
 
 tasks.named('check') {
-    dependsOn 'jacocoTestCoverageVerification'
+    //dependsOn 'jacocoTestCoverageVerification'
 }
 
 sonar {


### PR DESCRIPTION
## 📝작업 내용

- GitHub Branch protection rules에서 `SonarCloud Code Analysis` 를 Required status check에서 제거
- Gradle: `jacocoTestReport` → `jacocoTestCoverageVerification` 자동 실행(finalizedBy) 연결 제거
- Gradle: `check` task가 `jacocoTestCoverageVerification`에 의존하지 않도록 수정

<br/>

## 👀변경 사항

- 당분간 커버리지로 머지 차단 없음 / 품질관리는 추후 재도입

<br/>


## #️⃣관련 이슈

- closes #21 