### PR TITLE
[TR1L-83] fix: Liquibase gradle 분리

### DIFF
--- a/apps/api-server/build.gradle
+++ b/apps/api-server/build.gradle
@@ -1,4 +1,4 @@
-tasks.named("bootJar"){
+tasks.named("bootJar") {
     archiveFileName = "api-server.jar"
 }
 
@@ -10,4 +10,7 @@ dependencies {
     implementation "org.springframework.boot:spring-boot-starter-data-jpa:3.5.9"
     implementation group: 'org.postgresql', name: 'postgresql', version: '42.7.7'
     runtimeOnly("org.postgresql:postgresql")
+
+    //Liquibase
+    implementation "org.liquibase:liquibase-core:4.30.0"
 }

--- a/apps/worker/build.gradle
+++ b/apps/worker/build.gradle
@@ -27,4 +27,7 @@ dependencies {
     implementation "software.amazon.awssdk:auth"
     implementation "software.amazon.awssdk:aws-core"
     implementation "software.amazon.awssdk:sdk-core"
+
+    //Liquibase
+    implementation "org.liquibase:liquibase-core:4.30.0"
 }

--- a/shared/build.gradle
+++ b/shared/build.gradle
@@ -1,7 +1,4 @@
 dependencies {
     api "org.slf4j:slf4j-api:2.0.16"
     api "net.logstash.logback:logstash-logback-encoder:8.0"
-
-    //Liquibase
-    api "org.liquibase:liquibase-core:4.30.0"
 }


### PR DESCRIPTION
## 📝작업 내용
<!-- 작업한 내용들 명시 -->

- `Liquibase` 의존성 `api-server`, `worker build.gradle` 종속성으로 이동

<br/>

## 👀변경 사항
<!-- 팀원들이 알아야할 코드, 설정, 구조의 변경을 명시 -->


<br/>

## 🎫 Jira Ticket
- Jira Ticket: TR1L-83

<br/>

## #️⃣관련 이슈

- closes #115 