### PR TITLE
[TR1L-121] fix: Job1 - Step3 전체 병렬 처리 수정

### DIFF
--- a/apps/worker/src/main/java/com/tr1l/worker/batch/calculatejob/step/step3/WorkDocClaimAndTargetRowReader.java
+++ b/apps/worker/src/main/java/com/tr1l/worker/batch/calculatejob/step/step3/WorkDocClaimAndTargetRowReader.java
@@ -25,6 +25,8 @@ public class WorkDocClaimAndTargetRowReader
     private final int fetchSize; //
     private final Duration leaseDuration;
     private final String workerId;
+    private final int partitionIndex;
+    private final int partitionCount;
 
     private final Deque<WorkAndTargetRow> buffer = new ArrayDeque<>();
     private long totalClaimNanos = 0L;
@@ -37,7 +39,9 @@ public class WorkDocClaimAndTargetRowReader
             YearMonth billingMonth,
             int fetchSize,
             Duration leaseDuration,
-            String workerId
+            String workerId,
+            int partitionIndex,
+            int partitionCount
     ) {
         this.claimPort = claimPort;
         this.targetLoadPort = targetLoadPort;
@@ -45,6 +49,8 @@ public class WorkDocClaimAndTargetRowReader
         this.fetchSize = fetchSize;
         this.leaseDuration = leaseDuration;
         this.workerId = workerId;
+        this.partitionIndex = partitionIndex;
+        this.partitionCount = partitionCount;
         setName("step3WorkDocClaimAndTargetRowReader");
     }
 
@@ -57,7 +63,15 @@ public class WorkDocClaimAndTargetRowReader
             // status: target -> processing
             long claimStart = System.nanoTime();
             List<WorkDocClaimPort.ClaimedWorkDoc> claimed =
-                    claimPort.claim(billingMonth, fetchSize, leaseDuration, workerId, now);
+                    claimPort.claim(
+                            billingMonth,
+                            fetchSize,
+                            leaseDuration,
+                            workerId,
+                            now,
+                            partitionIndex,
+                            partitionCount
+                    );
             long claimNanos = System.nanoTime() - claimStart;
 
             if (claimed.isEmpty()) {

--- a/apps/worker/src/main/java/com/tr1l/worker/batch/calculatejob/support/WorkerIdPartitioner.java
+++ b/apps/worker/src/main/java/com/tr1l/worker/batch/calculatejob/support/WorkerIdPartitioner.java
@@ -22,6 +22,8 @@ public class WorkerIdPartitioner implements Partitioner {
         for (int i = 0; i < gridSize; i++) {
             ExecutionContext ctx = new ExecutionContext();
             ctx.putString("workerId", workerIdPrefix + "-" + i);
+            ctx.putInt("partitionIndex", i);
+            ctx.putInt("partitionCount", gridSize);
             result.put("partition-" + i, ctx);
         }
         return result;

--- a/apps/worker/src/main/java/com/tr1l/worker/config/step/BillingCalculateAndSnapshotConfig.java
+++ b/apps/worker/src/main/java/com/tr1l/worker/config/step/BillingCalculateAndSnapshotConfig.java
@@ -100,12 +100,16 @@ public class BillingCalculateAndSnapshotConfig {
             @Value("${app.billing.step3.fetch-size}") int fetchSize,
             @Value("${app.billing.step3.lease-seconds:500}") long leaseSeconds,
             @Qualifier("billingWorkerId") String workerId,
-            @Value("#{stepExecutionContext['workerId']}") String partitionWorkerId
+            @Value("#{stepExecutionContext['workerId']}") String partitionWorkerId,
+            @Value("#{stepExecutionContext['partitionIndex']}") Integer partitionIndex,
+            @Value("#{stepExecutionContext['partitionCount']}") Integer partitionCount
     ) {
         YearMonth billingMonth = YearMonth.parse(billingYearMonth); // YYYY-MM
         String effectiveWorkerId = (partitionWorkerId == null || partitionWorkerId.isBlank())
                 ? workerId
                 : partitionWorkerId;
+        int effectivePartitionIndex = (partitionIndex == null) ? 0 : partitionIndex;
+        int effectivePartitionCount = (partitionCount == null || partitionCount <= 0) ? 1 : partitionCount;
 
         return new WorkDocClaimAndTargetRowReader(
                 claimPort,
@@ -113,7 +117,9 @@ public class BillingCalculateAndSnapshotConfig {
                 billingMonth,
                 fetchSize,
                 Duration.ofSeconds(leaseSeconds),
-                effectiveWorkerId
+                effectiveWorkerId,
+                effectivePartitionIndex,
+                effectivePartitionCount
         );
     }
 

--- a/apps/worker/src/main/resources/application.yml
+++ b/apps/worker/src/main/resources/application.yml
@@ -58,14 +58,14 @@ app:
 
       #Step01 - SQL1 fetch size
       reader:
-        fetchSize: 30000
-        bulkSize: 5000
+        fetchSize: 10000
+        bulkSize: 10000
       chunk:
         chunkSize: 10000
 
   billing:
     step3:
-      chunk-size: 10000
+      chunk-size: 2000
       fetch-size: 2000
       partition:
         grid-size: 8
@@ -80,7 +80,7 @@ app:
       # multi thread
       chunk-size: 1500
       pool-size: 6
-      fetch-size: 10000
+      fetch-size: 2000
       lease-seconds: 500
 
     step2:

--- a/contexts/billing/src/main/java/com/tr1l/billing/application/port/out/WorkDocClaimPort.java
+++ b/contexts/billing/src/main/java/com/tr1l/billing/application/port/out/WorkDocClaimPort.java
@@ -14,7 +14,15 @@ import java.util.List;
  * - attemptCount: +1
  */
 public interface WorkDocClaimPort {
-    List<ClaimedWorkDoc> claim(YearMonth billingMonth, int limit, Duration leaseDuration, String workerId, Instant now);
+    List<ClaimedWorkDoc> claim(
+            YearMonth billingMonth,
+            int limit,
+            Duration leaseDuration,
+            String workerId,
+            Instant now,
+            int partitionIndex,
+            int partitionCount
+    );
 
     record ClaimedWorkDoc(
             String id,          // billingMonth:userId -> "2026-01-01:12345"


### PR DESCRIPTION
## 📝작업 내용
<!-- 작업한 내용들 명시 -->
- Step3 작업을 파티션별로 분산 클레임하도록 userId modulo 조건을 추가해 병렬 처리량을 높임

<br/>

## 👀변경 사항
<!-- 팀원들이 알아야할 코드, 설정, 구조의 변경을 명시 -->

  - `WorkDocClaimPort`에 파티션 인덱스/카운트를 전달하도록 시그니처 확장 (`contexts/billing/src/main/java/com/tr1l/billing/application/port/out/WorkDocClaimPort.java`)
  - 파티션 컨텍스트에 index/count 주입 (`apps/worker/src/main/java/com/tr1l/worker/batch/calculatejob/support/WorkerIdPartitioner.java`)
  - Reader가 파티션 정보를 받아 claim 호출 (`apps/worker/src/main/java/com/tr1l/worker/batch/calculatejob/step/step3/WorkDocClaimAndTargetRowReader.java`)
  - Mongo claim 쿼리에 `userId % partitionCount == partitionIndex` 조건 추가 (`contexts/billing/src/main/java/com/tr1l/billing/adapter/out/persistence/mongo/MongoWorkDocClaimAdapter.java`)
  - Step3 reader 설정에서 파티션 정보 주입 (`apps/worker/src/main/java/com/tr1l/worker/config/step/BillingCalculateAndSnapshotConfig.java`)

<br/>

## 🎫 Jira Ticket
- Jira Ticket: TR1L-121

<br/>

## #️⃣관련 이슈

- closes #240 