### PR TITLE
[TR1L-155] test: Job1 rerun 검증 기반 추가

### DIFF
--- a/apps/worker/build.gradle
+++ b/apps/worker/build.gradle
@@ -43,4 +43,7 @@ dependencies {
 
     // SQL query counting (datasource proxy)
     implementation "net.ttddyy:datasource-proxy:1.10"
+
+    testImplementation 'io.qameta.allure:allure-junit5:2.29.1'
+    testImplementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml'
 }

--- a/apps/worker/src/test/java/com/tr1l/worker/reliability/Job1BaselineValidationTest.java
+++ b/apps/worker/src/test/java/com/tr1l/worker/reliability/Job1BaselineValidationTest.java
@@ -1,0 +1,190 @@
+package com.tr1l.worker.reliability;
+
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import com.tr1l.worker.reliability.dataset.ExpectedSummary;
+import com.tr1l.worker.reliability.invariant.CrossDbInvariantChecks;
+import com.tr1l.worker.reliability.invariant.InvariantValidationResult;
+import com.tr1l.worker.reliability.invariant.InvariantValidator;
+import com.tr1l.worker.reliability.invariant.Job1StateCollector;
+import com.tr1l.worker.reliability.invariant.Job1StateSnapshot;
+import com.tr1l.worker.reliability.invariant.PostgresInvariantChecks;
+import com.tr1l.worker.reliability.invariant.RunStateComparisonCalculator;
+import com.tr1l.worker.reliability.invariant.RunStateComparisonResult;
+import com.tr1l.worker.reliability.scenario.Job1ScenarioDefinition;
+import com.tr1l.worker.reliability.support.AllureEvidenceWriter;
+import com.tr1l.worker.reliability.support.JsonResultWriter;
+import com.tr1l.worker.reliability.support.ReliabilityDataSourceFactory;
+import com.tr1l.worker.reliability.support.ReliabilityObjectMappers;
+import com.tr1l.worker.reliability.support.ReliabilityResourceCatalog;
+import com.tr1l.worker.reliability.support.ReliabilityRuntimeConfig;
+import io.qameta.allure.Allure;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Tag("job1-reliability")
+// 로컬 환경 전용 검증
+// 현재 타깃 디비 몽고 상태 직접 대조
+// S-001 run 직후 상태 스냅샷 먼저 생성
+// 그 다음 같은 cutoff 재실행 비교 순서
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class Job1BaselineValidationTest {
+    private final ReliabilityResourceCatalog catalog = new ReliabilityResourceCatalog();
+    private final JsonResultWriter resultWriter = new JsonResultWriter();
+    private final AllureEvidenceWriter evidenceWriter = new AllureEvidenceWriter();
+    private final ReliabilityDataSourceFactory dataSourceFactory = new ReliabilityDataSourceFactory();
+    private final RunStateComparisonCalculator comparisonCalculator = new RunStateComparisonCalculator();
+
+    @Test
+    @Order(1)
+    @DisplayName("S-001 run이 끝난 직후의 Postgres Mongo 상태가 맞는지 보기")
+    void normalRunFinalStateShouldSatisfyActiveInvariants() throws Exception {
+        assumeLocalReliabilityEnabled();
+
+        // S-001 run 직후 상태 검증
+        Job1ScenarioDefinition scenario = catalog.loadScenario("S-001");
+        ExpectedSummary expectedSummary = catalog.loadExpectedSummary(scenario.datasetId());
+        ReliabilityRuntimeConfig config = ReliabilityRuntimeConfig.fromEnvironment();
+
+        attachScenarioLabels(scenario);
+        evidenceWriter.attachJson("scenario.json", scenario);
+        evidenceWriter.attachJson("dataset-expected-summary.json", expectedSummary);
+
+        try (MongoClient mongoClient = MongoClients.create(config.mongoUri())) {
+            // 상태 스냅샷 수집 경로
+            NamedParameterJdbcTemplate jdbcTemplate =
+                    new NamedParameterJdbcTemplate(dataSourceFactory.createTargetDataSource(config));
+
+            Job1StateCollector stateCollector = new Job1StateCollector(
+                    jdbcTemplate,
+                    mongoClient,
+                    config.mongoDatabase(),
+                    config.snapshotCollection()
+            );
+
+            // postgres 교차 저장소 검증 조합
+            InvariantValidator validator = new InvariantValidator(
+                    new PostgresInvariantChecks(jdbcTemplate, catalog),
+                    new CrossDbInvariantChecks(jdbcTemplate, mongoClient, config, catalog)
+            );
+
+            Job1StateSnapshot snapshot = stateCollector.collect(LocalDate.parse(scenario.job().billingMonthDay()));
+            InvariantValidationResult validationResult = validator.validate(scenario, catalog.loadActiveInvariants());
+
+            // 결과 파일 저장
+            resultWriter.write(scenario, "state-snapshot.json", snapshot);
+            resultWriter.write(scenario, "invariant-validation.json", validationResult);
+
+            evidenceWriter.attachJson("state-snapshot.json", snapshot);
+            evidenceWriter.attachJson("invariant-validation.json", validationResult);
+
+            // D1 기대 범위 대조
+            assertSnapshotWithinExpected(snapshot, expectedSummary);
+            assertThat(validationResult.allPassed()).isTrue();
+        }
+    }
+
+    @Test
+    @Order(2)
+    @DisplayName("S-001R 같은 cutoff로 다시 돌린 뒤 S-001 run 직후 상태와 count가 같은지 보기")
+    void sameCutoffRerunShouldPreserveBaselineCounts() throws Exception {
+        assumeLocalReliabilityEnabled();
+
+        // 재실행 뒤 현재 상태와 S-001 run 직후 상태 비교 경로
+        Job1ScenarioDefinition scenario = catalog.loadScenario("S-001R");
+        Job1ScenarioDefinition referenceScenario = catalog.loadScenario("S-001");
+        ReliabilityRuntimeConfig config = ReliabilityRuntimeConfig.fromEnvironment();
+
+        attachScenarioLabels(scenario);
+        evidenceWriter.attachJson("scenario.json", scenario);
+
+        // S-001 run 직후 상태 스냅샷 선행 생성 조건
+        Path referenceSnapshotPath = resultWriter.scenarioDirectory(referenceScenario).resolve("state-snapshot.json");
+        assertThat(Files.exists(referenceSnapshotPath))
+                .as("Run S-001 first to produce %s", referenceSnapshotPath)
+                .isTrue();
+
+        Job1StateSnapshot referenceSnapshot =
+                ReliabilityObjectMappers.json().readValue(Files.readString(referenceSnapshotPath), Job1StateSnapshot.class);
+
+        try (MongoClient mongoClient = MongoClients.create(config.mongoUri())) {
+            // 재실행 현재 상태 수집
+            NamedParameterJdbcTemplate jdbcTemplate =
+                    new NamedParameterJdbcTemplate(dataSourceFactory.createTargetDataSource(config));
+
+            Job1StateCollector stateCollector = new Job1StateCollector(
+                    jdbcTemplate,
+                    mongoClient,
+                    config.mongoDatabase(),
+                    config.snapshotCollection()
+            );
+
+        // 불변 조건 검증과 S-001 run 직후 상태 비교 분리
+            InvariantValidator validator = new InvariantValidator(
+                    new PostgresInvariantChecks(jdbcTemplate, catalog),
+                    new CrossDbInvariantChecks(jdbcTemplate, mongoClient, config, catalog)
+            );
+
+            Job1StateSnapshot currentSnapshot = stateCollector.collect(LocalDate.parse(scenario.job().billingMonthDay()));
+            InvariantValidationResult validationResult = validator.validate(scenario, catalog.loadActiveInvariants());
+            RunStateComparisonResult comparisonResult = comparisonCalculator.compare(
+                    scenario.id(),
+                    scenario.compareWithBaseline().baselineScenarioId(),
+                    referenceSnapshot,
+                    currentSnapshot,
+                    scenario.compareWithBaseline().metrics()
+            );
+
+            // 재실행 비교 결과 저장
+            resultWriter.write(scenario, "s001-run-state-snapshot.json", referenceSnapshot);
+            resultWriter.write(scenario, "current-state-snapshot.json", currentSnapshot);
+            resultWriter.write(scenario, "s001-run-state-comparison.json", comparisonResult);
+            resultWriter.write(scenario, "invariant-validation.json", validationResult);
+
+            evidenceWriter.attachJson("s001-run-state-snapshot.json", referenceSnapshot);
+            evidenceWriter.attachJson("current-state-snapshot.json", currentSnapshot);
+            evidenceWriter.attachJson("s001-run-state-comparison.json", comparisonResult);
+            evidenceWriter.attachJson("invariant-validation.json", validationResult);
+
+            assertThat(validationResult.allPassed()).isTrue();
+            assertThat(comparisonResult.matched()).isTrue();
+        }
+    }
+
+    private void assumeLocalReliabilityEnabled() {
+        // 로컬 준비 미완료 시 건너뜀
+        Assumptions.assumeTrue(
+                "true".equalsIgnoreCase(System.getenv("JOB1_RELIABILITY_ENABLED")),
+                "Set JOB1_RELIABILITY_ENABLED=true to run local Job1 reliability validation"
+        );
+    }
+
+    private void attachScenarioLabels(Job1ScenarioDefinition scenario) {
+        Allure.label("epic", scenario.allure().epic());
+        Allure.label("feature", scenario.allure().feature());
+        Allure.label("story", scenario.allure().story());
+    }
+
+    private void assertSnapshotWithinExpected(Job1StateSnapshot snapshot, ExpectedSummary expectedSummary) {
+        // 기대 범위 기준 검증
+        assertThat(expectedSummary.expected().billingTargets().contains(snapshot.billingTargetsCount())).isTrue();
+        assertThat(expectedSummary.expected().billingWork().contains(snapshot.billingWorkCount())).isTrue();
+        assertThat(expectedSummary.expected().mongoSnapshotsAfterNormalRun().contains(snapshot.mongoSnapshotCount())).isTrue();
+        assertThat(snapshot.failedCount()).isEqualTo(expectedSummary.expected().failedAfterNormalRun());
+        assertThat(snapshot.staleProcessingCount()).isEqualTo(expectedSummary.expected().staleProcessingAfterRerun());
+        assertThat(snapshot.duplicateBillingWorkCount()).isEqualTo(expectedSummary.expected().duplicateBillingWork());
+        assertThat(snapshot.duplicateMongoSnapshotCount()).isEqualTo(expectedSummary.expected().duplicateMongoWorkId());
+    }
+}

--- a/apps/worker/src/test/java/com/tr1l/worker/reliability/Job1ReliabilityResourceContractTest.java
+++ b/apps/worker/src/test/java/com/tr1l/worker/reliability/Job1ReliabilityResourceContractTest.java
@@ -1,0 +1,72 @@
+package com.tr1l.worker.reliability;
+
+import com.tr1l.worker.reliability.dataset.ExpectedSummary;
+import com.tr1l.worker.reliability.dataset.Job1DatasetDefinition;
+import com.tr1l.worker.reliability.invariant.InvariantDefinition;
+import com.tr1l.worker.reliability.scenario.Job1ScenarioDefinition;
+import com.tr1l.worker.reliability.support.ReliabilityResourceCatalog;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+// 상시 실행 대상
+// 리소스 구조 선검증 용도
+class Job1ReliabilityResourceContractTest {
+    private final ReliabilityResourceCatalog catalog = new ReliabilityResourceCatalog();
+
+    @Test
+    @DisplayName("D1 데이터셋 값이 지금 기준이랑 맞는지 보기")
+    void d1DatasetContract_should_be_consistent() {
+        // D1 데이터셋 계약 검증
+        Job1DatasetDefinition dataset = catalog.loadDataset("D1-rerun-mvp");
+        ExpectedSummary expectedSummary = catalog.loadExpectedSummary("D1-rerun-mvp");
+
+        assertThat(dataset.id()).isEqualTo("D1-rerun-mvp");
+        assertThat(dataset.billingMonthDay()).isEqualTo("2026-01-01");
+        assertThat(dataset.billingYearMonth()).isEqualTo("2026-01");
+        assertThat(dataset.scale().usersTotal()).isEqualTo(30_000);
+        assertThat(dataset.scale().targetEligible()).isEqualTo(28_500);
+        assertThat(expectedSummary.datasetId()).isEqualTo(dataset.id());
+        assertThat(expectedSummary.expected().billingTargets().contains(28_500)).isTrue();
+        assertThat(expectedSummary.expected().billingWork().contains(28_500)).isTrue();
+        assertThat(expectedSummary.expected().mongoSnapshotsAfterNormalRun().contains(28_500)).isTrue();
+    }
+
+    @Test
+    @DisplayName("active invariant 파일이 실제 체크 파일이랑 이어지는지 보기")
+    void activeInvariants_should_reference_existing_checks() {
+        // 불변 조건 리소스 연결 검증
+        List<InvariantDefinition> invariants = catalog.loadActiveInvariants();
+
+        assertThat(invariants).hasSize(3);
+        assertThat(invariants).extracting(InvariantDefinition::id)
+                .containsExactly("INV-001", "INV-002", "INV-003");
+        assertThat(invariants).allSatisfy(definition -> {
+            assertThat(catalog.resourceExists(definition.checkRef()))
+                    .as("checkRef exists for %s", definition.id())
+                    .isTrue();
+            assertThat(definition.description()).isNotBlank();
+            assertThat(definition.scope()).isNotBlank();
+        });
+    }
+
+    @Test
+    @DisplayName("S-001 시나리오가 D1 run 직후 상태 스냅샷 기준으로 보게 되어 있는지 보기")
+    void baselineScenarios_should_target_d1_and_known_invariants() {
+        // S-001 run 직후 상태 스냅샷 시나리오 구조
+        // 후속 시나리오 기준점 용도
+        Job1ScenarioDefinition normalRun = catalog.loadScenario("S-001");
+        Job1ScenarioDefinition rerun = catalog.loadScenario("S-001R");
+
+        assertThat(normalRun.datasetId()).isEqualTo("D1-rerun-mvp");
+        assertThat(normalRun.validate().invariants()).containsExactly("INV-001", "INV-002", "INV-003");
+        assertThat(rerun.datasetId()).isEqualTo("D1-rerun-mvp");
+        assertThat(rerun.compareWithBaseline()).isNotNull();
+        assertThat(rerun.compareWithBaseline().baselineScenarioId()).isEqualTo("S-001");
+        assertThat(rerun.compareWithBaseline().metrics())
+                .contains("billingTargetsCount", "billingWorkCount", "calculatedCount", "mongoSnapshotCount");
+    }
+}

--- a/apps/worker/src/test/java/com/tr1l/worker/reliability/dataset/ExpectedSummary.java
+++ b/apps/worker/src/test/java/com/tr1l/worker/reliability/dataset/ExpectedSummary.java
@@ -1,0 +1,33 @@
+package com.tr1l.worker.reliability.dataset;
+
+// 기대값 범위 정의
+public record ExpectedSummary(
+        String datasetId,
+        String billingMonthDay,
+        String billingYearMonth,
+        Expected expected
+) {
+    // 정확한 수치 고정 전 범위값
+    public record Expected(
+            long usersTotal,
+            long targetEligible,
+            Range billingTargets,
+            Range billingWork,
+            Range mongoSnapshotsAfterNormalRun,
+            long failedAfterNormalRun,
+            long staleProcessingAfterRerun,
+            long duplicateBillingWork,
+            long duplicateMongoWorkId
+    ) {
+    }
+
+    // 범위 검증 전용 타입
+    public record Range(
+            long min,
+            long max
+    ) {
+        public boolean contains(long value) {
+            return value >= min && value <= max;
+        }
+    }
+}

--- a/apps/worker/src/test/java/com/tr1l/worker/reliability/dataset/Job1DatasetDefinition.java
+++ b/apps/worker/src/test/java/com/tr1l/worker/reliability/dataset/Job1DatasetDefinition.java
@@ -1,0 +1,23 @@
+package com.tr1l.worker.reliability.dataset;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+// 데이터셋 메타 파일 형태
+public record Job1DatasetDefinition(
+        String id,
+        String description,
+        String cutoff,
+        String billingMonthDay,
+        String billingYearMonth,
+        Scale scale,
+        JsonNode distribution,
+        JsonNode expected
+) {
+    // 규모 정보 전용 영역
+    public record Scale(
+            long usersTotal,
+            long targetEligible,
+            long excluded
+    ) {
+    }
+}

--- a/apps/worker/src/test/java/com/tr1l/worker/reliability/invariant/CrossDbInvariantChecks.java
+++ b/apps/worker/src/test/java/com/tr1l/worker/reliability/invariant/CrossDbInvariantChecks.java
@@ -1,0 +1,127 @@
+package com.tr1l.worker.reliability.invariant;
+
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Filters;
+import com.tr1l.worker.reliability.support.ReliabilityObjectMappers;
+import com.tr1l.worker.reliability.support.ReliabilityResourceCatalog;
+import com.tr1l.worker.reliability.support.ReliabilityRuntimeConfig;
+import org.bson.Document;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+// postgres 몽고 최종 상태 대조
+// 부분 성공 경계 우선 검증
+public final class CrossDbInvariantChecks {
+    private static final int MAX_SAMPLES = 10;
+
+    private final NamedParameterJdbcTemplate jdbcTemplate;
+    private final MongoClient mongoClient;
+    private final ReliabilityRuntimeConfig runtimeConfig;
+    private final ReliabilityResourceCatalog catalog;
+
+    public CrossDbInvariantChecks(
+            NamedParameterJdbcTemplate jdbcTemplate,
+            MongoClient mongoClient,
+            ReliabilityRuntimeConfig runtimeConfig,
+            ReliabilityResourceCatalog catalog
+    ) {
+        this.jdbcTemplate = jdbcTemplate;
+        this.mongoClient = mongoClient;
+        this.runtimeConfig = runtimeConfig;
+        this.catalog = catalog;
+    }
+
+    public InvariantResult execute(InvariantDefinition definition, LocalDate billingMonthDay) {
+        // yaml 명세 우선 적용
+        CrossDbCheckSpec spec = catalog.loadCheckText(definition.checkRef()).isBlank()
+                ? null
+                : parseSpec(definition.checkRef());
+
+        // 기본 calculated workId 조회 쿼리
+        String postgresQuery = spec == null ? """
+                SELECT to_char(billing_month_day, 'YYYY-MM-DD') || ':' || user_id AS work_id
+                FROM billing_work
+                WHERE billing_month_day = :billingMonthDay
+                  AND status = 'CALCULATED'
+                """ : spec.postgresQuery();
+
+        Set<String> calculatedWorkIds = jdbcTemplate.queryForList(
+                        postgresQuery,
+                        new MapSqlParameterSource("billingMonthDay", billingMonthDay),
+                        String.class
+                )
+                .stream()
+                .collect(Collectors.toSet());
+
+        String collectionName = spec == null ? runtimeConfig.snapshotCollection() : spec.mongo().collection();
+        String workIdField = spec == null ? "workId" : spec.mongo().workIdField();
+        String billingMonthField = spec == null ? "billingMonth" : spec.mongo().billingMonthField();
+
+        // 몽고 동일 billingMonth 범위 조회
+        MongoCollection<Document> collection = mongoClient
+                .getDatabase(runtimeConfig.mongoDatabase())
+                .getCollection(collectionName);
+
+        Set<String> mongoWorkIds = collection.find(Filters.eq(billingMonthField, billingMonthDay.toString()))
+                .projection(new Document(workIdField, 1).append("_id", 0))
+                .into(new java.util.ArrayList<>())
+                .stream()
+                .map(document -> document.getString(workIdField))
+                .filter(java.util.Objects::nonNull)
+                .collect(Collectors.toSet());
+
+        // 전체 누락 건수 집계
+        // 샘플 행 제한 첨부
+        long missingCount = calculatedWorkIds.stream()
+                .filter(workId -> !mongoWorkIds.contains(workId))
+                .count();
+
+        List<Map<String, Object>> missing = calculatedWorkIds.stream()
+                .filter(workId -> !mongoWorkIds.contains(workId))
+                .sorted()
+                .limit(MAX_SAMPLES)
+                .map(workId -> Map.<String, Object>of("workId", workId))
+                .toList();
+
+        return new InvariantResult(
+                definition.id(),
+                definition.title(),
+                definition.scope(),
+                definition.checkType(),
+                missingCount == definition.expectedViolationCount(),
+                Math.toIntExact(missingCount),
+                missing
+        );
+    }
+
+    private CrossDbCheckSpec parseSpec(String classpathLocation) {
+        try {
+            // 명세 파싱 실패 시 예외 전파
+            return ReliabilityObjectMappers.yaml()
+                    .readValue(catalog.loadCheckText(classpathLocation), CrossDbCheckSpec.class);
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to parse cross-db check spec: " + classpathLocation, e);
+        }
+    }
+
+    private record CrossDbCheckSpec(
+            String id,
+            String postgresQuery,
+            Mongo mongo
+    ) {
+    }
+
+    private record Mongo(
+            String collection,
+            String workIdField,
+            String billingMonthField
+    ) {
+    }
+}

--- a/apps/worker/src/test/java/com/tr1l/worker/reliability/invariant/InvariantCheckType.java
+++ b/apps/worker/src/test/java/com/tr1l/worker/reliability/invariant/InvariantCheckType.java
@@ -1,0 +1,11 @@
+package com.tr1l.worker.reliability.invariant;
+
+// PR1 허용 체크 타입
+public enum InvariantCheckType {
+    POSTGRES,
+    CROSS_DB;
+
+    public static InvariantCheckType from(String raw) {
+        return InvariantCheckType.valueOf(raw.replace('-', '_').toUpperCase());
+    }
+}

--- a/apps/worker/src/test/java/com/tr1l/worker/reliability/invariant/InvariantDefinition.java
+++ b/apps/worker/src/test/java/com/tr1l/worker/reliability/invariant/InvariantDefinition.java
@@ -1,0 +1,21 @@
+package com.tr1l.worker.reliability.invariant;
+
+// 활성 불변 조건 리소스 형태
+public record InvariantDefinition(
+        String id,
+        String title,
+        String category,
+        String scope,
+        String description,
+        String checkType,
+        String checkRef,
+        int expectedViolationCount,
+        String severity,
+        Boolean allowedTransientViolation,
+        String allureFeature,
+        String allureStory
+) {
+    public InvariantCheckType type() {
+        return InvariantCheckType.from(checkType);
+    }
+}

--- a/apps/worker/src/test/java/com/tr1l/worker/reliability/invariant/InvariantResult.java
+++ b/apps/worker/src/test/java/com/tr1l/worker/reliability/invariant/InvariantResult.java
@@ -1,0 +1,16 @@
+package com.tr1l.worker.reliability.invariant;
+
+import java.util.List;
+import java.util.Map;
+
+// 불변 조건 단건 결과 모델
+public record InvariantResult(
+        String invariantId,
+        String title,
+        String scope,
+        String checkType,
+        boolean passed,
+        int violationCount,
+        List<Map<String, Object>> sampleViolations
+) {
+}

--- a/apps/worker/src/test/java/com/tr1l/worker/reliability/invariant/InvariantValidationResult.java
+++ b/apps/worker/src/test/java/com/tr1l/worker/reliability/invariant/InvariantValidationResult.java
@@ -1,0 +1,17 @@
+package com.tr1l.worker.reliability.invariant;
+
+import java.time.Instant;
+import java.util.List;
+
+// 시나리오 단위 결과 묶음
+public record InvariantValidationResult(
+        String scenarioId,
+        String billingMonthDay,
+        String validationPhase,
+        Instant checkedAt,
+        List<InvariantResult> results
+) {
+    public boolean allPassed() {
+        return results.stream().allMatch(InvariantResult::passed);
+    }
+}

--- a/apps/worker/src/test/java/com/tr1l/worker/reliability/invariant/InvariantValidator.java
+++ b/apps/worker/src/test/java/com/tr1l/worker/reliability/invariant/InvariantValidator.java
@@ -1,0 +1,65 @@
+package com.tr1l.worker.reliability.invariant;
+
+import com.tr1l.worker.reliability.scenario.Job1ScenarioDefinition;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Set;
+
+// 시나리오 선택 불변 조건 실행기
+// 단순 실행 흐름 유지
+public final class InvariantValidator {
+    private final PostgresInvariantChecks postgresChecks;
+    private final CrossDbInvariantChecks crossDbChecks;
+
+    public InvariantValidator(
+            PostgresInvariantChecks postgresChecks,
+            CrossDbInvariantChecks crossDbChecks
+    ) {
+        this.postgresChecks = postgresChecks;
+        this.crossDbChecks = crossDbChecks;
+    }
+
+    public InvariantValidationResult validate(
+            Job1ScenarioDefinition scenario,
+            List<InvariantDefinition> activeInvariants
+    ) {
+        // 시나리오 기준 billingMonthDay
+        // 파라미터 계산 로직 배제
+        LocalDate billingMonthDay = LocalDate.parse(scenario.job().billingMonthDay());
+        String phase = scenario.validate().phase();
+        Set<String> selectedIds = Set.copyOf(scenario.validate().invariants());
+
+        // 범위 불일치 불변 조건 제외
+        List<InvariantResult> results = activeInvariants.stream()
+                .filter(definition -> selectedIds.contains(definition.id()))
+                .filter(definition -> scopeApplies(definition.scope(), phase))
+                .map(definition -> switch (definition.type()) {
+                    case POSTGRES -> postgresChecks.execute(definition, billingMonthDay);
+                    case CROSS_DB -> crossDbChecks.execute(definition, billingMonthDay);
+                })
+                .toList();
+
+        return new InvariantValidationResult(
+                scenario.id(),
+                billingMonthDay.toString(),
+                phase,
+                Instant.now(),
+                results
+        );
+    }
+
+    private boolean scopeApplies(String scope, String phase) {
+        // S-001R 에서도 같은 범위 재사용
+        // 최종 상태 기준 통일
+        if ("always".equalsIgnoreCase(scope)) {
+            return true;
+        }
+        if (scope.equalsIgnoreCase(phase)) {
+            return true;
+        }
+        return "after_rerun_complete".equalsIgnoreCase(scope)
+                && "after_job_complete".equalsIgnoreCase(phase);
+    }
+}

--- a/apps/worker/src/test/java/com/tr1l/worker/reliability/invariant/Job1StateCollector.java
+++ b/apps/worker/src/test/java/com/tr1l/worker/reliability/invariant/Job1StateCollector.java
@@ -1,0 +1,129 @@
+package com.tr1l.worker.reliability.invariant;
+
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Accumulators;
+import com.mongodb.client.model.Aggregates;
+import com.mongodb.client.model.Filters;
+import org.bson.Document;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+
+// 상태 카운트 수집기
+// 시나리오 공통 수치 집약
+public final class Job1StateCollector {
+    private final NamedParameterJdbcTemplate jdbcTemplate;
+    private final MongoClient mongoClient;
+    private final String mongoDatabase;
+    private final String snapshotCollection;
+
+    public Job1StateCollector(
+            NamedParameterJdbcTemplate jdbcTemplate,
+            MongoClient mongoClient,
+            String mongoDatabase,
+            String snapshotCollection
+    ) {
+        this.jdbcTemplate = jdbcTemplate;
+        this.mongoClient = mongoClient;
+        this.mongoDatabase = mongoDatabase;
+        this.snapshotCollection = snapshotCollection;
+    }
+
+    public Job1StateSnapshot collect(LocalDate billingMonthDay) {
+        MapSqlParameterSource params = new MapSqlParameterSource("billingMonthDay", billingMonthDay);
+
+        // 명시적 카운트 쿼리 유지
+        // 보고서 대조 기준
+        long billingTargetsCount = queryForLong("""
+                SELECT COUNT(*)
+                FROM billing_targets
+                WHERE billing_month = :billingMonthDay
+                """, params);
+
+        long billingWorkCount = queryForLong("""
+                SELECT COUNT(*)
+                FROM billing_work
+                WHERE billing_month_day = :billingMonthDay
+                """, params);
+
+        Map<String, Long> statusCounts = jdbcTemplate.query("""
+                        SELECT status, COUNT(*) AS count
+                        FROM billing_work
+                        WHERE billing_month_day = :billingMonthDay
+                        GROUP BY status
+                        """,
+                params,
+                rs -> {
+                    java.util.Map<String, Long> counts = new java.util.HashMap<>();
+                    while (rs.next()) {
+                        counts.put(rs.getString("status"), rs.getLong("count"));
+                    }
+                    return counts;
+                });
+
+        // stale PROCESSING 집계
+        // lease 만료 상태 기준
+        long staleProcessingCount = queryForLong("""
+                SELECT COUNT(*)
+                FROM billing_work
+                WHERE billing_month_day = :billingMonthDay
+                  AND status = 'PROCESSING'
+                  AND lease_until < now()
+                """, params);
+
+        long duplicateBillingWorkCount = queryForLong("""
+                SELECT COUNT(*)
+                FROM (
+                    SELECT user_id
+                    FROM billing_work
+                    WHERE billing_month_day = :billingMonthDay
+                    GROUP BY user_id
+                    HAVING COUNT(*) > 1
+                ) duplicates
+                """, params);
+
+        // 스냅샷 동일 월 범위
+        MongoCollection<Document> collection = mongoClient
+                .getDatabase(mongoDatabase)
+                .getCollection(snapshotCollection);
+
+        // 몽고 중복 workId 집계
+        long mongoSnapshotCount = collection.countDocuments(Filters.eq("billingMonth", billingMonthDay.toString()));
+
+        List<Document> duplicateDocs = collection.aggregate(List.of(
+                Aggregates.match(Filters.eq("billingMonth", billingMonthDay.toString())),
+                Aggregates.group("$workId", Accumulators.sum("count", 1)),
+                Aggregates.match(Filters.gt("count", 1)),
+                Aggregates.limit(10)
+        )).into(new java.util.ArrayList<>());
+
+        // 샘플 행 제한 수집
+        // 발표 디버깅 공용 근거
+        return new Job1StateSnapshot(
+                billingMonthDay.toString(),
+                Instant.now(),
+                billingTargetsCount,
+                billingWorkCount,
+                statusCounts.getOrDefault("TARGET", 0L),
+                statusCounts.getOrDefault("PROCESSING", 0L),
+                statusCounts.getOrDefault("CALCULATED", 0L),
+                statusCounts.getOrDefault("FAILED", 0L),
+                staleProcessingCount,
+                duplicateBillingWorkCount,
+                mongoSnapshotCount,
+                duplicateDocs.size(),
+                duplicateDocs.stream().map(doc -> doc.getString("_id")).toList()
+        );
+    }
+
+    private long queryForLong(String sql, MapSqlParameterSource params) {
+        // 공통 count 조회
+        Long result = jdbcTemplate.queryForObject(sql, params, Long.class);
+        return result == null ? 0 : result;
+    }
+}

--- a/apps/worker/src/test/java/com/tr1l/worker/reliability/invariant/Job1StateSnapshot.java
+++ b/apps/worker/src/test/java/com/tr1l/worker/reliability/invariant/Job1StateSnapshot.java
@@ -1,0 +1,38 @@
+package com.tr1l.worker.reliability.invariant;
+
+import java.time.Instant;
+import java.util.List;
+
+// S-001 run 직후 상태 카운트 묶음
+public record Job1StateSnapshot(
+        String billingMonthDay,
+        Instant capturedAt,
+        long billingTargetsCount,
+        long billingWorkCount,
+        long targetCount,
+        long processingCount,
+        long calculatedCount,
+        long failedCount,
+        long staleProcessingCount,
+        long duplicateBillingWorkCount,
+        long mongoSnapshotCount,
+        long duplicateMongoSnapshotCount,
+        List<String> sampleDuplicateMongoWorkIds
+) {
+    // 시나리오 지표 이름 매핑
+    public long metricValue(String metricName) {
+        return switch (metricName) {
+            case "billingTargetsCount" -> billingTargetsCount;
+            case "billingWorkCount" -> billingWorkCount;
+            case "targetCount" -> targetCount;
+            case "processingCount" -> processingCount;
+            case "calculatedCount" -> calculatedCount;
+            case "failedCount" -> failedCount;
+            case "staleProcessingCount" -> staleProcessingCount;
+            case "duplicateBillingWorkCount" -> duplicateBillingWorkCount;
+            case "mongoSnapshotCount" -> mongoSnapshotCount;
+            case "duplicateMongoSnapshotCount" -> duplicateMongoSnapshotCount;
+            default -> throw new IllegalArgumentException("Unsupported metric: " + metricName);
+        };
+    }
+}

--- a/apps/worker/src/test/java/com/tr1l/worker/reliability/invariant/PostgresInvariantChecks.java
+++ b/apps/worker/src/test/java/com/tr1l/worker/reliability/invariant/PostgresInvariantChecks.java
@@ -1,0 +1,43 @@
+package com.tr1l.worker.reliability.invariant;
+
+import com.tr1l.worker.reliability.support.ReliabilityResourceCatalog;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+
+// postgres sql 체크 실행기
+public final class PostgresInvariantChecks {
+    private static final int MAX_SAMPLES = 10;
+
+    private final NamedParameterJdbcTemplate jdbcTemplate;
+    private final ReliabilityResourceCatalog catalog;
+
+    public PostgresInvariantChecks(
+            NamedParameterJdbcTemplate jdbcTemplate,
+            ReliabilityResourceCatalog catalog
+    ) {
+        this.jdbcTemplate = jdbcTemplate;
+        this.catalog = catalog;
+    }
+
+    public InvariantResult execute(InvariantDefinition definition, LocalDate billingMonthDay) {
+        String sql = catalog.loadCheckText(definition.checkRef());
+        List<Map<String, Object>> rows = jdbcTemplate.queryForList(
+                sql,
+                new MapSqlParameterSource("billingMonthDay", billingMonthDay)
+        );
+
+        return new InvariantResult(
+                definition.id(),
+                definition.title(),
+                definition.scope(),
+                definition.checkType(),
+                rows.size() == definition.expectedViolationCount(),
+                rows.size(),
+                rows.stream().limit(MAX_SAMPLES).toList()
+        );
+    }
+}

--- a/apps/worker/src/test/java/com/tr1l/worker/reliability/invariant/RunStateComparisonCalculator.java
+++ b/apps/worker/src/test/java/com/tr1l/worker/reliability/invariant/RunStateComparisonCalculator.java
@@ -1,0 +1,48 @@
+package com.tr1l.worker.reliability.invariant;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+// S-001 run 직후 상태와 현재 상태 비교기
+public final class RunStateComparisonCalculator {
+
+    public RunStateComparisonResult compare(
+            String scenarioId,
+            String referenceScenarioId,
+            Job1StateSnapshot referenceSnapshot,
+            Job1StateSnapshot currentSnapshot,
+            List<String> metrics
+    ) {
+        // S-001 run 직후 수치 보관 맵
+        Map<String, Long> referenceMetrics = new LinkedHashMap<>();
+        // 현재 수치 보관 맵
+        Map<String, Long> currentMetrics = new LinkedHashMap<>();
+        // 달라진 항목 모음
+        List<RunStateComparisonResult.Difference> differences = new ArrayList<>();
+
+        for (String metric : metrics) {
+            long referenceValue = referenceSnapshot.metricValue(metric);
+            long currentValue = currentSnapshot.metricValue(metric);
+
+            referenceMetrics.put(metric, referenceValue);
+            currentMetrics.put(metric, currentValue);
+
+            if (referenceValue != currentValue) {
+                differences.add(new RunStateComparisonResult.Difference(metric, referenceValue, currentValue));
+            }
+        }
+
+        return new RunStateComparisonResult(
+                scenarioId,
+                referenceScenarioId,
+                Instant.now(),
+                differences.isEmpty(),
+                referenceMetrics,
+                currentMetrics,
+                differences
+        );
+    }
+}

--- a/apps/worker/src/test/java/com/tr1l/worker/reliability/invariant/RunStateComparisonResult.java
+++ b/apps/worker/src/test/java/com/tr1l/worker/reliability/invariant/RunStateComparisonResult.java
@@ -1,0 +1,24 @@
+package com.tr1l.worker.reliability.invariant;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+// S-001 run 직후 상태 비교 결과
+public record RunStateComparisonResult(
+        String scenarioId,
+        String referenceScenarioId,
+        Instant comparedAt,
+        boolean matched,
+        Map<String, Long> referenceMetrics,
+        Map<String, Long> currentMetrics,
+        List<Difference> differences
+) {
+    // 달라진 지표 항목
+    public record Difference(
+            String metric,
+            long referenceValue,
+            long currentValue
+    ) {
+    }
+}

--- a/apps/worker/src/test/java/com/tr1l/worker/reliability/scenario/Job1ScenarioDefinition.java
+++ b/apps/worker/src/test/java/com/tr1l/worker/reliability/scenario/Job1ScenarioDefinition.java
@@ -1,0 +1,60 @@
+package com.tr1l.worker.reliability.scenario;
+
+import java.util.List;
+
+// 시나리오 리소스 형태
+public record Job1ScenarioDefinition(
+        String id,
+        String name,
+        String description,
+        String datasetId,
+        Job job,
+        Fault fault,
+        Rerun rerun,
+        Validate validate,
+        CompareWithBaseline compareWithBaseline,
+        AllureLabels allure
+) {
+    public record Job(
+            String name,
+            String cutoff,
+            String billingMonthDay
+    ) {
+    }
+
+    public record Fault(
+            boolean enabled
+    ) {
+    }
+
+    public record Rerun(
+            boolean enabled,
+            Boolean sameCutoff
+    ) {
+    }
+
+    public record Validate(
+            String phase,
+            List<String> invariants
+    ) {
+    }
+
+    public record CompareWithBaseline(
+            boolean enabled,
+            String baselineScenarioId,
+            List<String> metrics
+    ) {
+    }
+
+    public record AllureLabels(
+            String epic,
+            String feature,
+            String story
+    ) {
+    }
+
+    // build 아티팩트 이름 정규화
+    public String artifactDirectoryName() {
+        return (id + "-" + name).replaceAll("[^a-zA-Z0-9-_]+", "-");
+    }
+}

--- a/apps/worker/src/test/java/com/tr1l/worker/reliability/support/AllureEvidenceWriter.java
+++ b/apps/worker/src/test/java/com/tr1l/worker/reliability/support/AllureEvidenceWriter.java
@@ -1,0 +1,19 @@
+package com.tr1l.worker.reliability.support;
+
+import io.qameta.allure.Allure;
+
+// Allure 근거 파일 부착기
+public final class AllureEvidenceWriter {
+
+    public void attachJson(String name, Object value) {
+        try {
+            Allure.addAttachment(name, "application/json", ReliabilityObjectMappers.json().writeValueAsString(value), ".json");
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to attach JSON evidence: " + name, e);
+        }
+    }
+
+    public void attachText(String name, String value) {
+        Allure.addAttachment(name, "text/plain", value, ".txt");
+    }
+}

--- a/apps/worker/src/test/java/com/tr1l/worker/reliability/support/JsonResultWriter.java
+++ b/apps/worker/src/test/java/com/tr1l/worker/reliability/support/JsonResultWriter.java
@@ -1,0 +1,30 @@
+package com.tr1l.worker.reliability.support;
+
+import com.tr1l.worker.reliability.scenario.Job1ScenarioDefinition;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+// build 하위 결과 json 저장
+public final class JsonResultWriter {
+    private final Path baseDir = Paths.get("build", "job1-reliability-results");
+
+    public Path write(Job1ScenarioDefinition scenario, String fileName, Object value) {
+        Path dir = scenarioDirectory(scenario);
+        try {
+            Files.createDirectories(dir);
+            Path output = dir.resolve(fileName);
+            Files.writeString(output, ReliabilityObjectMappers.json().writeValueAsString(value), StandardCharsets.UTF_8);
+            return output;
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to write scenario artifact: " + fileName, e);
+        }
+    }
+
+    public Path scenarioDirectory(Job1ScenarioDefinition scenario) {
+        return baseDir.resolve(scenario.artifactDirectoryName());
+    }
+}

--- a/apps/worker/src/test/java/com/tr1l/worker/reliability/support/ReliabilityDataSourceFactory.java
+++ b/apps/worker/src/test/java/com/tr1l/worker/reliability/support/ReliabilityDataSourceFactory.java
@@ -1,0 +1,18 @@
+package com.tr1l.worker.reliability.support;
+
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+
+import javax.sql.DataSource;
+
+// 타깃 디비 datasource 생성
+public final class ReliabilityDataSourceFactory {
+
+    public DataSource createTargetDataSource(ReliabilityRuntimeConfig config) {
+        DriverManagerDataSource dataSource = new DriverManagerDataSource();
+        dataSource.setDriverClassName("org.postgresql.Driver");
+        dataSource.setUrl(config.targetJdbcUrl());
+        dataSource.setUsername(config.targetJdbcUsername());
+        dataSource.setPassword(config.targetJdbcPassword());
+        return dataSource;
+    }
+}

--- a/apps/worker/src/test/java/com/tr1l/worker/reliability/support/ReliabilityObjectMappers.java
+++ b/apps/worker/src/test/java/com/tr1l/worker/reliability/support/ReliabilityObjectMappers.java
@@ -1,0 +1,40 @@
+package com.tr1l.worker.reliability.support;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+// object mapper 설정 집약
+public final class ReliabilityObjectMappers {
+    private static final ObjectMapper JSON = buildJsonMapper();
+    private static final ObjectMapper YAML = buildYamlMapper();
+
+    private ReliabilityObjectMappers() {
+    }
+
+    public static ObjectMapper json() {
+        return JSON;
+    }
+
+    public static ObjectMapper yaml() {
+        return YAML;
+    }
+
+    private static ObjectMapper buildJsonMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new JavaTimeModule());
+        mapper.findAndRegisterModules();
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        mapper.enable(SerializationFeature.INDENT_OUTPUT);
+        return mapper;
+    }
+
+    private static ObjectMapper buildYamlMapper() {
+        ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+        mapper.registerModule(new JavaTimeModule());
+        mapper.findAndRegisterModules();
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        return mapper;
+    }
+}

--- a/apps/worker/src/test/java/com/tr1l/worker/reliability/support/ReliabilityResourceCatalog.java
+++ b/apps/worker/src/test/java/com/tr1l/worker/reliability/support/ReliabilityResourceCatalog.java
@@ -1,0 +1,86 @@
+package com.tr1l.worker.reliability.support;
+
+import com.tr1l.worker.reliability.dataset.ExpectedSummary;
+import com.tr1l.worker.reliability.dataset.Job1DatasetDefinition;
+import com.tr1l.worker.reliability.invariant.InvariantDefinition;
+import com.tr1l.worker.reliability.scenario.Job1ScenarioDefinition;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+
+// reliability 리소스 위치 집약
+// 경로 문자열 분산 방지
+public final class ReliabilityResourceCatalog {
+    private final ReliabilityResourceLoader loader = new ReliabilityResourceLoader();
+    private final PathMatchingResourcePatternResolver resolver = new PathMatchingResourcePatternResolver();
+
+    public Job1DatasetDefinition loadDataset(String datasetId) {
+        return loader.loadYaml("reliability/datasets/" + datasetId + "/dataset.yml", Job1DatasetDefinition.class);
+    }
+
+    public ExpectedSummary loadExpectedSummary(String datasetId) {
+        return loader.loadJson("reliability/datasets/" + datasetId + "/expected-summary.json", ExpectedSummary.class);
+    }
+
+    public List<InvariantDefinition> loadActiveInvariants() {
+        return readJsonDirectory("classpath*:reliability/invariants/active/*.json", InvariantDefinition.class);
+    }
+
+    public Job1ScenarioDefinition loadScenario(String scenarioId) {
+        try {
+            Resource[] resources = resolver.getResources("classpath*:reliability/scenarios/*.yml");
+            return Arrays.stream(resources)
+                    // 시나리오 id 기준 매칭
+                    // 접두어 혼선 방지
+                    .map(resource -> {
+                        try {
+                            return ReliabilityObjectMappers.yaml().readValue(resource.getInputStream(), Job1ScenarioDefinition.class);
+                        } catch (IOException e) {
+                            throw new IllegalStateException("Failed to read scenario resource: " + resource, e);
+                        }
+                    })
+                    .filter(definition -> scenarioId.equals(definition.id()))
+                    .findFirst()
+                    .orElseThrow(() -> new IllegalStateException("Scenario resource not found for id: " + scenarioId));
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to resolve scenario resources", e);
+        }
+    }
+
+    public String loadCheckText(String classpathLocation) {
+        return loader.loadText(classpathLocation);
+    }
+
+    public boolean resourceExists(String classpathLocation) {
+        return loader.exists(classpathLocation);
+    }
+
+    private <T> List<T> readJsonDirectory(String pattern, Class<T> type) {
+        try {
+            Resource[] resources = resolver.getResources(pattern);
+            return Arrays.stream(resources)
+                    // 고정 순서 정렬
+                    .sorted(Comparator.comparing(resource -> {
+                        try {
+                            return resource.getFilename();
+                        } catch (Exception e) {
+                            return "";
+                        }
+                    }))
+                    .map(resource -> {
+                        try {
+                            return ReliabilityObjectMappers.json().readValue(resource.getInputStream(), type);
+                        } catch (IOException e) {
+                            throw new IllegalStateException("Failed to read resource " + resource, e);
+                        }
+                    })
+                    .toList();
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to resolve resources: " + pattern, e);
+        }
+    }
+}

--- a/apps/worker/src/test/java/com/tr1l/worker/reliability/support/ReliabilityResourceLoader.java
+++ b/apps/worker/src/test/java/com/tr1l/worker/reliability/support/ReliabilityResourceLoader.java
@@ -1,0 +1,47 @@
+package com.tr1l.worker.reliability.support;
+
+import org.springframework.core.io.ClassPathResource;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+// 테스트 리소스 로드 전용
+public final class ReliabilityResourceLoader {
+
+    public <T> T loadJson(String classpathLocation, Class<T> type) {
+        try (InputStream inputStream = open(classpathLocation)) {
+            return ReliabilityObjectMappers.json().readValue(inputStream, type);
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to load JSON resource: " + classpathLocation, e);
+        }
+    }
+
+    public <T> T loadYaml(String classpathLocation, Class<T> type) {
+        try (InputStream inputStream = open(classpathLocation)) {
+            return ReliabilityObjectMappers.yaml().readValue(inputStream, type);
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to load YAML resource: " + classpathLocation, e);
+        }
+    }
+
+    public String loadText(String classpathLocation) {
+        try (InputStream inputStream = open(classpathLocation)) {
+            return new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to load text resource: " + classpathLocation, e);
+        }
+    }
+
+    public boolean exists(String classpathLocation) {
+        return new ClassPathResource(classpathLocation).exists();
+    }
+
+    private InputStream open(String classpathLocation) throws IOException {
+        ClassPathResource resource = new ClassPathResource(classpathLocation);
+        if (!resource.exists()) {
+            throw new IllegalStateException("Classpath resource not found: " + classpathLocation);
+        }
+        return resource.getInputStream();
+    }
+}

--- a/apps/worker/src/test/java/com/tr1l/worker/reliability/support/ReliabilityRuntimeConfig.java
+++ b/apps/worker/src/test/java/com/tr1l/worker/reliability/support/ReliabilityRuntimeConfig.java
@@ -1,0 +1,27 @@
+package com.tr1l.worker.reliability.support;
+
+// 로컬 기본값 묶음
+public record ReliabilityRuntimeConfig(
+        String targetJdbcUrl,
+        String targetJdbcUsername,
+        String targetJdbcPassword,
+        String mongoUri,
+        String mongoDatabase,
+        String snapshotCollection
+) {
+    public static ReliabilityRuntimeConfig fromEnvironment() {
+        return new ReliabilityRuntimeConfig(
+                env("PG_SUB_HOST", "jdbc:postgresql://localhost:5433/billing_target"),
+                env("PG_SUB_USER", "postgres"),
+                env("PG_SUB_PASSWORD", "postgres"),
+                env("MONGODB_URI", "mongodb://localhost:27017/tr1l"),
+                env("JOB1_RELIABILITY_MONGO_DB", "tr1l"),
+                env("JOB1_RELIABILITY_SNAPSHOT_COLLECTION", "billing_snapshot")
+        );
+    }
+
+    private static String env(String key, String defaultValue) {
+        String value = System.getenv(key);
+        return value == null || value.isBlank() ? defaultValue : value;
+    }
+}

--- a/apps/worker/src/test/resources/allure.properties
+++ b/apps/worker/src/test/resources/allure.properties
@@ -1,0 +1,1 @@
+allure.results.directory=build/allure-results

--- a/apps/worker/src/test/resources/reliability/checks/cross-db/INV-003-calculated-work-has-snapshot.yml
+++ b/apps/worker/src/test/resources/reliability/checks/cross-db/INV-003-calculated-work-has-snapshot.yml
@@ -1,0 +1,10 @@
+id: INV-003
+postgresQuery: |
+  SELECT to_char(billing_month_day, 'YYYY-MM-DD') || ':' || user_id AS work_id
+  FROM billing_work
+  WHERE billing_month_day = :billingMonthDay
+    AND status = 'CALCULATED'
+mongo:
+  collection: billing_snapshot
+  workIdField: workId
+  billingMonthField: billingMonth

--- a/apps/worker/src/test/resources/reliability/checks/postgres/INV-001.sql
+++ b/apps/worker/src/test/resources/reliability/checks/postgres/INV-001.sql
@@ -1,0 +1,7 @@
+-- 같은 월 같은 사용자 work 중복 확인
+-- rerun 뒤에도 이 값은 0 유지 기대
+SELECT billing_month_day, user_id, COUNT(*) AS duplicate_count
+FROM billing_work
+WHERE billing_month_day = :billingMonthDay
+GROUP BY billing_month_day, user_id
+HAVING COUNT(*) > 1;

--- a/apps/worker/src/test/resources/reliability/checks/postgres/INV-002.sql
+++ b/apps/worker/src/test/resources/reliability/checks/postgres/INV-002.sql
@@ -1,0 +1,7 @@
+-- 재실행 끝난 뒤 남아있는 stale processing 확인
+-- lease 만료분이 남으면 회수 실패 의미
+SELECT billing_month_day, user_id, status, lease_until
+FROM billing_work
+WHERE billing_month_day = :billingMonthDay
+  AND status = 'PROCESSING'
+  AND lease_until < now();

--- a/apps/worker/src/test/resources/reliability/datasets/D1-rerun-mvp/dataset.yml
+++ b/apps/worker/src/test/resources/reliability/datasets/D1-rerun-mvp/dataset.yml
@@ -1,0 +1,53 @@
+id: D1-rerun-mvp
+description: Job1 rerun-safe baseline dataset for PR1
+cutoff: "2026-02-01T00:00:00Z"
+billingMonthDay: "2026-01-01"
+billingYearMonth: "2026-01"
+
+scale:
+  usersTotal: 30000
+  targetEligible: 28500
+  excluded: 1500
+
+distribution:
+  users:
+    activeWithPlan: 28500
+    withdrawn: 900
+    banned: 300
+    activeWithoutPlan: 300
+
+  usage:
+    targetMonthRows: 28500
+    previousMonthNoiseRows: 28500
+    nextMonthNoiseRows: 28500
+
+  usagePattern:
+    belowIncludedDataRatio: 0.50
+    exactlyIncludedDataRatio: 0.10
+    overIncludedDataRatio: 0.30
+    unlimitedPlanRatio: 0.10
+
+  contract:
+    activeCount: 8550
+    expiredCount: 1425
+
+  welfare:
+    eligibleCount: 5700
+
+  soldier:
+    activeCount: 1425
+    expiredCount: 285
+
+  options:
+    expectedTotalSubscriptions: 54000
+    noOptionRatio: 0.30
+    oneOptionRatio: 0.30
+    twoOrThreeOptionsRatio: 0.30
+    fourToSevenOptionsRatio: 0.10
+
+expected:
+  billingTargetsApprox: 28500
+  billingWorkApprox: 28500
+  mongoSnapshotsAfterNormalRunApprox: 28500
+  failedAfterNormalRun: 0
+  staleProcessingAfterRerun: 0

--- a/apps/worker/src/test/resources/reliability/datasets/D1-rerun-mvp/expected-summary.json
+++ b/apps/worker/src/test/resources/reliability/datasets/D1-rerun-mvp/expected-summary.json
@@ -1,0 +1,25 @@
+{
+  "datasetId": "D1-rerun-mvp",
+  "billingMonthDay": "2026-01-01",
+  "billingYearMonth": "2026-01",
+  "expected": {
+    "usersTotal": 30000,
+    "targetEligible": 28500,
+    "billingTargets": {
+      "min": 28400,
+      "max": 28600
+    },
+    "billingWork": {
+      "min": 28400,
+      "max": 28600
+    },
+    "mongoSnapshotsAfterNormalRun": {
+      "min": 28400,
+      "max": 28600
+    },
+    "failedAfterNormalRun": 0,
+    "staleProcessingAfterRerun": 0,
+    "duplicateBillingWork": 0,
+    "duplicateMongoWorkId": 0
+  }
+}

--- a/apps/worker/src/test/resources/reliability/datasets/D1-rerun-mvp/main-db/01_seed_d1.sql
+++ b/apps/worker/src/test/resources/reliability/datasets/D1-rerun-mvp/main-db/01_seed_d1.sql
@@ -1,0 +1,196 @@
+BEGIN;
+
+-- D1 전체 사용자 번호표 생성
+-- user 상태와 plan 분포 같이 고정
+CREATE TEMP TABLE d1_numbered_users AS
+SELECT
+    gs AS seq,
+    gs::bigint AS user_id,
+    CASE
+        WHEN gs <= 28500 THEN 'ACTIVE'
+        WHEN gs <= 29400 THEN 'WITHDRAWN'
+        WHEN gs <= 29700 THEN 'BANNED'
+        ELSE 'ACTIVE'
+    END AS user_status,
+    CASE
+        WHEN gs <= 28500 THEN
+            (ARRAY['PLN-001','PLN-002','PLN-005','PLN-011','PLN-018','PLN-043','PLN-050'])[((gs - 1) % 7) + 1]
+        WHEN gs <= 29700 THEN
+            (ARRAY['PLN-001','PLN-002','PLN-005'])[((gs - 1) % 3) + 1]
+        ELSE NULL
+    END AS plan_code,
+    CASE
+        WHEN gs <= 5700 THEN
+            (ARRAY['WLF-02','WLF-03','WLF-04','WLF-05'])[((gs - 1) % 4) + 1]
+        ELSE 'WLF-01'
+    END AS welfare_code
+FROM generate_series(1, 30000) AS gs;
+
+-- users 본문 적재
+-- Step1 대상 필터와 plan 분기 확인용
+INSERT INTO users (
+    user_id,
+    name,
+    email,
+    phone_number,
+    birth_date,
+    join_date,
+    plan_code,
+    welfare_code,
+    is_welfare,
+    user_role,
+    user_status,
+    from_time,
+    to_time,
+    day_time,
+    created_at,
+    modified_at
+)
+SELECT
+    nu.user_id,
+    '테스트유저' || nu.user_id,
+    'job1-d1-' || nu.user_id || '@example.com',
+    '010-' || lpad(((nu.seq - 1) / 10000)::text, 4, '0') || '-' || lpad(((nu.seq - 1) % 10000)::text, 4, '0'),
+    DATE '1985-01-01' + ((nu.seq - 1) % 10000),
+    DATE '2024-01-01' + ((nu.seq - 1) % 365),
+    nu.plan_code,
+    nu.welfare_code,
+    nu.welfare_code <> 'WLF-01',
+    'USER',
+    nu.user_status,
+    '08',
+    '22',
+    lpad((((nu.seq - 1) % 28) + 1)::text, 2, '0'),
+    TIMESTAMPTZ '2025-01-01 00:00:00+09' + ((nu.seq - 1) % 365) * INTERVAL '1 day',
+    NOW()
+FROM d1_numbered_users nu;
+
+-- 월별 usage 적재
+-- 기준 월과 앞뒤 noise 월 같이 주입
+INSERT INTO monthly_data_usage (
+    user_id,
+    usage_year_month,
+    used_data_mb,
+    usage_aggregated_at
+)
+SELECT
+    user_id,
+    ym,
+    CASE
+        WHEN ym = '2026-01' THEN 500 + ((seq - 1) % 5000)
+        WHEN ym = '2025-12' THEN 300 + ((seq - 1) % 4000)
+        ELSE 700 + ((seq - 1) % 4500)
+    END,
+    CASE
+        WHEN ym = '2026-01' THEN TIMESTAMPTZ '2026-01-31 23:59:59+09'
+        WHEN ym = '2025-12' THEN TIMESTAMPTZ '2025-12-31 23:59:59+09'
+        ELSE TIMESTAMPTZ '2026-02-28 23:59:59+09'
+    END
+FROM (
+    SELECT seq, user_id
+    FROM d1_numbered_users
+    WHERE seq <= 28500
+) eligible
+CROSS JOIN (
+    VALUES ('2025-12'), ('2026-01'), ('2026-02')
+) months(ym);
+
+-- active contract 적재
+-- 기준 월 안에서 유효한 계약 구간
+INSERT INTO user_contract (
+    user_id,
+    start_date,
+    end_date
+)
+SELECT
+    user_id,
+    DATE '2025-01-01',
+    DATE '2027-01-01'
+FROM d1_numbered_users
+WHERE seq BETWEEN 1 AND 8550;
+
+-- expired contract 적재
+-- 기준 월 이전 종료 구간
+INSERT INTO user_contract (
+    user_id,
+    start_date,
+    end_date
+)
+SELECT
+    user_id,
+    DATE '2024-01-01',
+    DATE '2025-06-30'
+FROM d1_numbered_users
+WHERE seq BETWEEN 8551 AND 9975;
+
+-- active soldier 적재
+-- 기준 월 할인 적용 대상
+INSERT INTO user_soldier (
+    user_id,
+    start_date,
+    end_date
+)
+SELECT
+    user_id,
+    DATE '2025-08-01',
+    NULL
+FROM d1_numbered_users
+WHERE seq BETWEEN 1 AND 1425;
+
+-- expired soldier 적재
+-- 기준 월 제외 확인용
+INSERT INTO user_soldier (
+    user_id,
+    start_date,
+    end_date
+)
+SELECT
+    user_id,
+    DATE '2024-01-01',
+    DATE '2025-11-30'
+FROM d1_numbered_users
+WHERE seq BETWEEN 1426 AND 1710;
+
+-- 옵션 개수 분포 계산
+-- 1개 2개 3개 4개 구간 고정
+WITH option_counts AS (
+    SELECT
+        seq,
+        user_id,
+        CASE
+            WHEN seq <= 8550 THEN 1
+            WHEN seq <= 17100 THEN 2
+            WHEN seq <= 25650 THEN 3
+            WHEN seq <= 28500 THEN 4
+            ELSE 0
+        END AS option_count
+    FROM d1_numbered_users
+    WHERE seq <= 28500
+),
+ranked_options AS (
+    SELECT
+        oc.user_id,
+        os.option_service_code,
+        row_number() OVER (PARTITION BY oc.user_id ORDER BY os.option_service_code) AS option_rank,
+        oc.option_count
+    FROM option_counts oc
+    CROSS JOIN option_service os
+)
+-- 옵션 구독 적재
+-- Step1 포함 옵션 조회 입력값
+INSERT INTO user_option_subscription (
+    user_id,
+    option_service_code,
+    start_date,
+    end_date
+)
+SELECT
+    user_id,
+    option_service_code,
+    TIMESTAMPTZ '2025-12-01 00:00:00+09',
+    TIMESTAMPTZ '2026-12-31 23:59:59+09'
+FROM ranked_options
+WHERE option_rank <= option_count;
+
+-- D1 입력 적재 마무리
+COMMIT;

--- a/apps/worker/src/test/resources/reliability/datasets/D1-rerun-mvp/mongo/01_cleanup_2026_01.js
+++ b/apps/worker/src/test/resources/reliability/datasets/D1-rerun-mvp/mongo/01_cleanup_2026_01.js
@@ -1,0 +1,5 @@
+// 2026 01 snapshot 정리
+// baseline 재생성 전 비우기 목적
+db.getSiblingDB("tr1l").billing_snapshot.deleteMany({
+  billingMonth: "2026-01-01"
+})

--- a/apps/worker/src/test/resources/reliability/datasets/D1-rerun-mvp/target-db/01_cleanup_2026_01.sql
+++ b/apps/worker/src/test/resources/reliability/datasets/D1-rerun-mvp/target-db/01_cleanup_2026_01.sql
@@ -1,0 +1,12 @@
+-- 2026 01 work 정리
+-- rerun 전 target 상태 초기화 목적
+DELETE FROM billing_work
+WHERE billing_month_day = DATE '2026-01-01';
+
+-- 2026 01 targets 정리
+DELETE FROM billing_targets
+WHERE billing_month = DATE '2026-01-01';
+
+-- 2026 01 cycle 정리
+DELETE FROM billing_cycle
+WHERE billing_month = DATE '2026-01-01';

--- a/apps/worker/src/test/resources/reliability/invariants/active/INV-001-no-duplicate-billing-work.json
+++ b/apps/worker/src/test/resources/reliability/invariants/active/INV-001-no-duplicate-billing-work.json
@@ -1,0 +1,13 @@
+{
+  "id": "INV-001",
+  "title": "No duplicate billing_work",
+  "category": "state_consistency",
+  "scope": "always",
+  "description": "같은 billing_month_day + user_id 조합의 billing_work는 최대 1개여야 한다.",
+  "checkType": "postgres",
+  "checkRef": "reliability/checks/postgres/INV-001.sql",
+  "expectedViolationCount": 0,
+  "severity": "critical",
+  "allureFeature": "Rerun Safety",
+  "allureStory": "No duplicate billing work"
+}

--- a/apps/worker/src/test/resources/reliability/invariants/active/INV-002-no-stale-processing-after-rerun.json
+++ b/apps/worker/src/test/resources/reliability/invariants/active/INV-002-no-stale-processing-after-rerun.json
@@ -1,0 +1,14 @@
+{
+  "id": "INV-002",
+  "title": "No stale PROCESSING after rerun",
+  "category": "temporal",
+  "scope": "after_rerun_complete",
+  "description": "재실행이 완료된 뒤 lease_until이 만료된 PROCESSING work가 남아 있으면 안 된다.",
+  "checkType": "postgres",
+  "checkRef": "reliability/checks/postgres/INV-002.sql",
+  "expectedViolationCount": 0,
+  "severity": "critical",
+  "allowedTransientViolation": true,
+  "allureFeature": "Failure Recovery",
+  "allureStory": "No stale processing after rerun"
+}

--- a/apps/worker/src/test/resources/reliability/invariants/active/INV-003-calculated-work-has-snapshot.json
+++ b/apps/worker/src/test/resources/reliability/invariants/active/INV-003-calculated-work-has-snapshot.json
@@ -1,0 +1,14 @@
+{
+  "id": "INV-003",
+  "title": "Calculated work has Mongo snapshot",
+  "category": "referential",
+  "scope": "after_rerun_complete",
+  "description": "CALCULATED 상태의 billing_work는 MongoDB billing_snapshot에 대응되는 workId를 가져야 한다.",
+  "checkType": "cross_db",
+  "checkRef": "reliability/checks/cross-db/INV-003-calculated-work-has-snapshot.yml",
+  "expectedViolationCount": 0,
+  "severity": "critical",
+  "allowedTransientViolation": true,
+  "allureFeature": "Cross-DB Consistency",
+  "allureStory": "Calculated work has snapshot"
+}

--- a/apps/worker/src/test/resources/reliability/scenarios/S-001-normal-run.yml
+++ b/apps/worker/src/test/resources/reliability/scenarios/S-001-normal-run.yml
@@ -1,0 +1,28 @@
+id: S-001
+name: normal-run
+description: Job1 정상 실행 후 최종 정합성을 검증한다.
+
+datasetId: D1-rerun-mvp
+
+job:
+  name: calculateJob
+  cutoff: "2026-02-01T00:00:00Z"
+  billingMonthDay: "2026-01-01"
+
+fault:
+  enabled: false
+
+rerun:
+  enabled: false
+
+validate:
+  phase: after_job_complete
+  invariants:
+    - INV-001
+    - INV-002
+    - INV-003
+
+allure:
+  epic: "TR1L Job1 Reliability"
+  feature: "Baseline Validation"
+  story: "S-001 normal run"

--- a/apps/worker/src/test/resources/reliability/scenarios/S-001R-same-cutoff-rerun.yml
+++ b/apps/worker/src/test/resources/reliability/scenarios/S-001R-same-cutoff-rerun.yml
@@ -1,0 +1,39 @@
+id: S-001R
+name: same-cutoff-rerun
+description: 동일 cutoff로 Job1을 재실행한 뒤 target/work/snapshot count가 증가하지 않는지 검증한다.
+
+datasetId: D1-rerun-mvp
+
+job:
+  name: calculateJob
+  cutoff: "2026-02-01T00:00:00Z"
+  billingMonthDay: "2026-01-01"
+
+fault:
+  enabled: false
+
+rerun:
+  enabled: true
+  sameCutoff: true
+
+validate:
+  phase: after_rerun_complete
+  invariants:
+    - INV-001
+    - INV-002
+    - INV-003
+
+compareWithBaseline:
+  enabled: true
+  baselineScenarioId: S-001
+  metrics:
+    - billingTargetsCount
+    - billingWorkCount
+    - calculatedCount
+    - mongoSnapshotCount
+    - duplicateMongoSnapshotCount
+
+allure:
+  epic: "TR1L Job1 Reliability"
+  feature: "Baseline Validation"
+  story: "S-001R same cutoff rerun"

--- a/build.gradle
+++ b/build.gradle
@@ -108,6 +108,10 @@ repositories {
     mavenCentral()
 }
 
+tasks.withType(JavaCompile).configureEach {
+    options.encoding = 'UTF-8'
+}
+
 allprojects {
     repositories {
         mavenCentral()


### PR DESCRIPTION
## 📝작업 내용

이번 PR에서는 Job1을 한 번 정상 실행했을 때 상태가 어떻게 남는지 먼저 고정하고  
같은 cutoff로 다시 돌렸을 때 그 상태가 그대로 유지되는지 볼 수 있게 정리했습니다

- host main DB 입력 스키마 정렬
- D1 전용 입력 시드 추가
- active invariant 3종 추가
- JUnit 기반 validator 추가
- Allure attachment 추가
- `S-001` run 직후 Postgres Mongo 상태 검증 추가
- `S-001R` 재실행 뒤 `S-001` run 직후 상태와 비교하는 검증 추가


<br/>

## 👀변경 사항

### 이번 PR에서 바뀐 것

| 구분 | 변경 내용 | 이유 |
| --- | --- | --- |
| 데이터셋 | D1 메타데이터와 main DB 시드 SQL 추가 | 로컬에서도 같은 입력 조건으로 계속 돌리기 위해 |
| 환경 정렬 | host main DB schema data 적용 경로 정리 | worker가 실제 입력 테이블을 읽을 수 있게 맞추기 위해 |
| invariant | `INV-001` `INV-002` `INV-003` 추가 | 중복 work stale processing snapshot 정합성 확인용 |
| 테스트 | `Job1BaselineValidationTest` 추가 | `S-001` run 직후 상태와 rerun 뒤 상태 비교용 |
| 테스트 순서 | `S-001` 다음 `S-001R` 순서 고정 | `S-001` 결과 파일을 그대로 비교 기준으로 쓰기 위해 |
| 결과물 | json artifact와 Allure attachment 추가 | 리뷰와 발표 때 근거 파일로 바로 보기 위해 |

### 흐름

```mermaid
flowchart LR
    A["host main DB 정렬"] --> B["D1 시드 적재"]
    B --> C["worker 실행"]
    C --> D["S-001 run 직후 상태 저장"]
    D --> E["같은 cutoff로 worker 재실행"]
    E --> F["S-001R 에서 상태 비교"]
    F --> G["Invariant 검증"]
```

### 실행 결과

| 테스트 | 결과 | 비고 |
| --- | --- | --- |
| `Job1ReliabilityResourceContractTest` | PASS | 리소스 연결 확인 |
| `Job1BaselineValidationTest` `S-001` | PASS | `S-001` run 직후 상태 스냅샷 생성 |
| `Job1BaselineValidationTest` `S-001R` | PASS | 같은 cutoff rerun 뒤 count 증가 없음 |
| `Job1BaselineValidationTest` 전체 | PASS | 순서 포함해서 전체 green |

### D1 입력 수치

| 항목 | 수치 |
| --- | ---: |
| users total | 30000 |
| active with plan | 28500 |
| active without plan | 300 |
| withdrawn | 900 |
| banned | 300 |
| `monthly_data_usage` `2026-01` | 28500 |
| active contracts | 8550 |
| active soldiers | 1425 |
| option subscriptions | 62700 |

### `S-001` run 직후 상태와 `S-001R` 비교 수치

| 항목 | S-001 | S-001R |
| --- | ---: | ---: |
| billingTargetsCount | 28500 | 28500 |
| billingWorkCount | 28500 | 28500 |
| calculatedCount | 28500 | 28500 |
| mongoSnapshotCount | 28500 | 28500 |
| duplicateMongoSnapshotCount | 0 | 0 |
| staleProcessingCount | 0 | 0 |

### 참고 파일

- `apps/worker/build/job1-reliability-results/S-001-normal-run/state-snapshot.json`
- `apps/worker/build/job1-reliability-results/S-001-normal-run/invariant-validation.json`
- `apps/worker/build/job1-reliability-results/S-001R-same-cutoff-rerun/s001-run-state-snapshot.json`
- `apps/worker/build/job1-reliability-results/S-001R-same-cutoff-rerun/s001-run-state-comparison.json`
- `apps/worker/build/job1-reliability-results/S-001R-same-cutoff-rerun/invariant-validation.json`


<br/>

## 🎫 Jira Ticket
- Jira Ticket: TR1L-155

<br/>

## #️⃣관련 이슈

- closes #339
