### PR TITLE
[TR1L-157] feat: Job1 AI invariant generator MVP 추가

### DIFF
--- a/apps/worker/src/test/java/com/tr1l/worker/reliability/Job1AiInvariantGeneratorContractTest.java
+++ b/apps/worker/src/test/java/com/tr1l/worker/reliability/Job1AiInvariantGeneratorContractTest.java
@@ -89,6 +89,27 @@ class Job1AiInvariantGeneratorContractTest {
     }
 
     @Test
+    @DisplayName("코드펜스 앞뒤 설명이 붙어도 JSON 본문만 뽑는지 보기")
+    void parserShouldExtractCodeFenceEvenWithSurroundingText() {
+        // 응답 앞뒤 설명 텍스트 허용
+        String fencedResponseWithProse = """
+                아래는 요청한 invariant 후보입니다
+
+                ```json
+                %s
+                ```
+
+                필요하면 다음 단계에서 mutant 도 만들 수 있습니다
+                """.formatted(loader.loadText(SAMPLE_RESPONSE_PATH).trim());
+
+        List<GeneratedInvariantCandidate> candidates = parser.parse(fencedResponseWithProse);
+
+        assertThat(candidates).hasSize(4);
+        assertThat(candidates).extracting(GeneratedInvariantCandidate::id)
+                .containsExactly("INV-101", "INV-102", "INV-103", "INV-104");
+    }
+
+    @Test
     @DisplayName("허용되지 않은 scope 값이면 파싱 단계에서 바로 막는지 보기")
     void parserShouldRejectInvalidScopeValue() {
         // 후처리 검증 경계 확인

--- a/apps/worker/src/test/java/com/tr1l/worker/reliability/Job1AiInvariantGeneratorContractTest.java
+++ b/apps/worker/src/test/java/com/tr1l/worker/reliability/Job1AiInvariantGeneratorContractTest.java
@@ -1,0 +1,113 @@
+package com.tr1l.worker.reliability;
+
+import com.tr1l.worker.reliability.ai.GeneratedInvariantCandidate;
+import com.tr1l.worker.reliability.ai.GeneratedInvariantParser;
+import com.tr1l.worker.reliability.ai.Job1InvariantContextPack;
+import com.tr1l.worker.reliability.ai.Job1InvariantContextPackBuilder;
+import com.tr1l.worker.reliability.ai.Job1InvariantPrompt;
+import com.tr1l.worker.reliability.ai.Job1InvariantPromptComposer;
+import com.tr1l.worker.reliability.support.ReliabilityResourceLoader;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+// AI invariant generator 초안 계약 검증
+class Job1AiInvariantGeneratorContractTest {
+    private static final String SAMPLE_RESPONSE_PATH =
+            "reliability/invariants/generated/job1-invariant-candidates.sample.json";
+
+    private final Job1InvariantContextPackBuilder contextPackBuilder = new Job1InvariantContextPackBuilder();
+    private final Job1InvariantPromptComposer promptComposer = new Job1InvariantPromptComposer();
+    private final GeneratedInvariantParser parser = new GeneratedInvariantParser();
+    private final ReliabilityResourceLoader loader = new ReliabilityResourceLoader();
+
+    @Test
+    @DisplayName("Job1 invariant 입력 묶음에 판단 재료가 빠지지 않는지 보기")
+    void job1ContextPackShouldContainRequiredSections() {
+        // 컨텍스트 묶음 누락 방지
+        Job1InvariantContextPack contextPack = contextPackBuilder.build();
+
+        assertThat(contextPack.packId()).isEqualTo("job1-invariant-generator-mvp");
+        assertThat(contextPack.sources()).hasSize(6);
+        assertThat(contextPack.renderForUserPrompt())
+                .contains("billing_targets")
+                .contains("billing_work")
+                .contains("billing_snapshot")
+                .contains("TARGET -> PROCESSING")
+                .contains("snapshotSavePort.saveAll")
+                .contains("재실행 완료 뒤");
+    }
+
+    @Test
+    @DisplayName("LLM 요청 초안이 응답 규칙과 컨텍스트를 같이 묶는지 보기")
+    void promptDraftShouldContainSystemRulesAndUserContext() {
+        // 시스템 지시문과 사용자 입력 묶음 확인
+        Job1InvariantPrompt prompt = promptComposer.compose(contextPackBuilder.build());
+
+        assertThat(prompt.systemPrompt())
+                .contains("JSON 배열만 출력")
+                .contains("\"sql_check\"")
+                .contains("PROCESSING 상태");
+        assertThat(prompt.userPrompt())
+                .contains("=== billing_targets 테이블 DDL ===")
+                .contains("=== Step3 핵심 코드 ===")
+                .contains("응답은 JSON 배열만 반환");
+    }
+
+    @Test
+    @DisplayName("샘플 응답 JSON이 생성 후보 스키마로 읽히는지 보기")
+    void sampleResponseShouldParseToGeneratedInvariantCandidates() {
+        // 샘플 응답 스키마 파싱 검증
+        List<GeneratedInvariantCandidate> candidates = parser.loadFromResource(SAMPLE_RESPONSE_PATH);
+
+        assertThat(candidates).hasSize(4);
+        assertThat(candidates).extracting(GeneratedInvariantCandidate::id)
+                .containsExactly("INV-101", "INV-102", "INV-103", "INV-104");
+        assertThat(candidates).extracting(GeneratedInvariantCandidate::category)
+                .containsExactly("count_consistency", "state_consistency", "temporal", "referential");
+        assertThat(candidates).filteredOn(GeneratedInvariantCandidate::crossDb).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("코드펜스로 감싼 응답도 그대로 읽는지 보기")
+    void parserShouldAcceptCodeFencedJsonResponse() {
+        // 응답 포맷 흔들림 허용
+        String fencedResponse = """
+                ```json
+                %s
+                ```
+                """.formatted(loader.loadText(SAMPLE_RESPONSE_PATH).trim());
+
+        List<GeneratedInvariantCandidate> candidates = parser.parse(fencedResponse);
+
+        assertThat(candidates).hasSize(4);
+        assertThat(candidates.get(3).crossDb()).isTrue();
+    }
+
+    @Test
+    @DisplayName("허용되지 않은 scope 값이면 파싱 단계에서 바로 막는지 보기")
+    void parserShouldRejectInvalidScopeValue() {
+        // 후처리 검증 경계 확인
+        String invalidResponse = """
+                [
+                  {
+                    "id": "INV-999",
+                    "category": "temporal",
+                    "description": "잘못된 scope 샘플",
+                    "scope": "after_rerun",
+                    "sql_check": "SELECT 1",
+                    "violated_by": "scope 오기입",
+                    "severity": "major"
+                  }
+                ]
+                """;
+
+        assertThatThrownBy(() -> parser.parse(invalidResponse))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Failed to parse generated invariant response");
+    }
+}

--- a/apps/worker/src/test/java/com/tr1l/worker/reliability/Job1AiInvariantLiveGenerationTest.java
+++ b/apps/worker/src/test/java/com/tr1l/worker/reliability/Job1AiInvariantLiveGenerationTest.java
@@ -1,0 +1,104 @@
+package com.tr1l.worker.reliability;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.tr1l.worker.reliability.ai.AiArtifactWriter;
+import com.tr1l.worker.reliability.ai.GeneratedInvariantBatchEvaluation;
+import com.tr1l.worker.reliability.ai.GeneratedInvariantCandidate;
+import com.tr1l.worker.reliability.ai.GeneratedInvariantParser;
+import com.tr1l.worker.reliability.ai.GeneratedInvariantScorer;
+import com.tr1l.worker.reliability.ai.Job1InvariantContextPackBuilder;
+import com.tr1l.worker.reliability.ai.Job1InvariantPrompt;
+import com.tr1l.worker.reliability.ai.Job1InvariantPromptComposer;
+import com.tr1l.worker.reliability.ai.OpenAiInvariantGenerationResult;
+import com.tr1l.worker.reliability.ai.OpenAiInvariantRuntimeConfig;
+import com.tr1l.worker.reliability.ai.OpenAiResponsesInvariantGenerator;
+import com.tr1l.worker.reliability.support.AllureEvidenceWriter;
+import com.tr1l.worker.reliability.support.ReliabilityObjectMappers;
+import com.tr1l.worker.reliability.support.ReliabilityResourceCatalog;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Tag("job1-ai-live")
+// OpenAI 실호출 검증
+class Job1AiInvariantLiveGenerationTest {
+    private final Job1InvariantContextPackBuilder contextPackBuilder = new Job1InvariantContextPackBuilder();
+    private final Job1InvariantPromptComposer promptComposer = new Job1InvariantPromptComposer();
+    private final GeneratedInvariantParser parser = new GeneratedInvariantParser();
+    private final GeneratedInvariantScorer scorer = new GeneratedInvariantScorer();
+    private final ReliabilityResourceCatalog catalog = new ReliabilityResourceCatalog();
+    private final AiArtifactWriter artifactWriter = new AiArtifactWriter();
+    private final AllureEvidenceWriter evidenceWriter = new AllureEvidenceWriter();
+
+    @Test
+    @DisplayName("OpenAI gpt-5.4-mini로 Job1 invariant 후보를 생성하고 캡처 저장 보기")
+    void liveGenerationShouldCaptureOpenAiResponse() throws Exception {
+        // live 호출 조건 확인
+        Assumptions.assumeTrue(
+                "true".equalsIgnoreCase(System.getenv("JOB1_AI_INVARIANT_LIVE_ENABLED")),
+                "Set JOB1_AI_INVARIANT_LIVE_ENABLED=true to run OpenAI live generation"
+        );
+
+        OpenAiInvariantRuntimeConfig config = OpenAiInvariantRuntimeConfig.fromEnvironment();
+        Assumptions.assumeTrue(config.enabled(), "Set OPENAI_API_KEY to run OpenAI live generation");
+
+        Job1InvariantPrompt prompt = promptComposer.compose(contextPackBuilder.build());
+        OpenAiResponsesInvariantGenerator generator = new OpenAiResponsesInvariantGenerator(config);
+
+        long inputTokenCount = generator.countInputTokens(prompt);
+        OpenAiInvariantGenerationResult generationResult = generator.generate(prompt);
+        List<GeneratedInvariantCandidate> candidates = parser.parse(generationResult.outputText());
+        GeneratedInvariantBatchEvaluation evaluation = scorer.evaluate(candidates, catalog.loadActiveInvariants());
+
+        Path requestPath = artifactWriter.writeText(config.runName(), "request-body.json", generationResult.requestBody());
+        Path responsePath = artifactWriter.writeText(config.runName(), "response-body.json", generationResult.responseBody());
+        Path outputTextPath = artifactWriter.writeText(config.runName(), "response-output-text.json", prettyJson(generationResult.outputText()));
+        Path candidatesPath = artifactWriter.writeJson(config.runName(), "generated-candidates.json", candidates);
+        Path evaluationPath = artifactWriter.writeJson(config.runName(), "generated-candidate-evaluation.json", evaluation);
+        Path metricsPath = artifactWriter.writeJson(
+                config.runName(),
+                "generation-metrics.json",
+                Map.of(
+                        "model", config.model(),
+                        "responseId", generationResult.responseId(),
+                        "inputTokenCount", inputTokenCount,
+                        "usage", generationResult.usage(),
+                        "candidateCount", candidates.size(),
+                        "activeCandidateCount", evaluation.activeCandidateCount(),
+                        "reviewRequiredCount", evaluation.reviewRequiredCount(),
+                        "rejectCount", evaluation.rejectCount(),
+                        "averageScore", evaluation.averageScore()
+                )
+        );
+
+        evidenceWriter.attachText("request-body.json", generationResult.requestBody());
+        evidenceWriter.attachText("response-body.json", generationResult.responseBody());
+        evidenceWriter.attachJson("generated-candidates.json", candidates);
+        evidenceWriter.attachJson("generated-candidate-evaluation.json", evaluation);
+
+        assertThat(generationResult.responseId()).isNotBlank();
+        assertThat(generationResult.model()).isEqualTo(config.model());
+        assertThat(inputTokenCount).isPositive();
+        assertThat(candidates).isNotEmpty();
+        assertThat(evaluation.totalCandidates()).isEqualTo(candidates.size());
+        assertThat(requestPath).exists();
+        assertThat(responsePath).exists();
+        assertThat(outputTextPath).exists();
+        assertThat(candidatesPath).exists();
+        assertThat(evaluationPath).exists();
+        assertThat(metricsPath).exists();
+    }
+
+    // output text pretty 출력
+    private String prettyJson(String rawJson) throws Exception {
+        JsonNode root = ReliabilityObjectMappers.json().readTree(rawJson);
+        return ReliabilityObjectMappers.json().writeValueAsString(root);
+    }
+}

--- a/apps/worker/src/test/java/com/tr1l/worker/reliability/Job1AiInvariantScoringContractTest.java
+++ b/apps/worker/src/test/java/com/tr1l/worker/reliability/Job1AiInvariantScoringContractTest.java
@@ -1,0 +1,57 @@
+package com.tr1l.worker.reliability;
+
+import com.tr1l.worker.reliability.ai.AiArtifactWriter;
+import com.tr1l.worker.reliability.ai.GeneratedInvariantBatchEvaluation;
+import com.tr1l.worker.reliability.ai.GeneratedInvariantEvaluation;
+import com.tr1l.worker.reliability.ai.GeneratedInvariantParser;
+import com.tr1l.worker.reliability.ai.GeneratedInvariantPromotionDecision;
+import com.tr1l.worker.reliability.ai.GeneratedInvariantScorer;
+import com.tr1l.worker.reliability.support.ReliabilityResourceCatalog;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+// generated 후보 점수화 계약 검증
+class Job1AiInvariantScoringContractTest {
+    private static final String SAMPLE_RESPONSE_PATH =
+            "reliability/invariants/generated/job1-invariant-candidates.sample.json";
+    private static final String SCORE_RUN_NAME = "sample-generated-invariant-score";
+
+    private final ReliabilityResourceCatalog catalog = new ReliabilityResourceCatalog();
+    private final GeneratedInvariantParser parser = new GeneratedInvariantParser();
+    private final GeneratedInvariantScorer scorer = new GeneratedInvariantScorer();
+    private final AiArtifactWriter artifactWriter = new AiArtifactWriter();
+
+    @Test
+    @DisplayName("generated 후보 점수화 기준이 active 승격 후보와 중복 후보를 나누는지 보기")
+    void generatedCandidatesShouldBeScoredWithPromotionDecision() {
+        // 점수화 결과 검증
+        GeneratedInvariantBatchEvaluation evaluation = scorer.evaluate(
+                parser.loadFromResource(SAMPLE_RESPONSE_PATH),
+                catalog.loadActiveInvariants()
+        );
+
+        artifactWriter.writeJson(SCORE_RUN_NAME, "generated-candidate-evaluation.json", evaluation);
+
+        Map<String, GeneratedInvariantEvaluation> byId = evaluation.evaluations().stream()
+                .collect(Collectors.toMap(GeneratedInvariantEvaluation::invariantId, Function.identity()));
+
+        assertThat(evaluation.totalCandidates()).isEqualTo(4);
+        assertThat(evaluation.activeCandidateCount()).isEqualTo(1);
+        assertThat(evaluation.reviewRequiredCount()).isEqualTo(3);
+        assertThat(evaluation.rejectCount()).isEqualTo(0);
+        assertThat(evaluation.averageScore()).isGreaterThanOrEqualTo(85d);
+
+        assertThat(byId.get("INV-101").decision()).isEqualTo(GeneratedInvariantPromotionDecision.ACTIVE_CANDIDATE);
+        assertThat(byId.get("INV-101").novelAgainstActive()).isTrue();
+        assertThat(byId.get("INV-102").decision()).isEqualTo(GeneratedInvariantPromotionDecision.REVIEW_REQUIRED);
+        assertThat(byId.get("INV-102").matchedActiveInvariantId()).isEqualTo("INV-001");
+        assertThat(byId.get("INV-103").matchedActiveInvariantId()).isEqualTo("INV-002");
+        assertThat(byId.get("INV-104").matchedActiveInvariantId()).isEqualTo("INV-003");
+    }
+}

--- a/apps/worker/src/test/java/com/tr1l/worker/reliability/ai/AiArtifactWriter.java
+++ b/apps/worker/src/test/java/com/tr1l/worker/reliability/ai/AiArtifactWriter.java
@@ -1,0 +1,42 @@
+package com.tr1l.worker.reliability.ai;
+
+import com.tr1l.worker.reliability.support.ReliabilityObjectMappers;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+// AI 결과 파일 저장기
+public final class AiArtifactWriter {
+    private final Path baseDir = Paths.get("build", "job1-ai-invariant-results");
+
+    public Path writeJson(String runName, String fileName, Object value) {
+        Path dir = directory(runName);
+        try {
+            Files.createDirectories(dir);
+            Path output = dir.resolve(fileName);
+            Files.writeString(output, ReliabilityObjectMappers.json().writeValueAsString(value), StandardCharsets.UTF_8);
+            return output;
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to write AI json artifact: " + fileName, e);
+        }
+    }
+
+    public Path writeText(String runName, String fileName, String value) {
+        Path dir = directory(runName);
+        try {
+            Files.createDirectories(dir);
+            Path output = dir.resolve(fileName);
+            Files.writeString(output, value, StandardCharsets.UTF_8);
+            return output;
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to write AI text artifact: " + fileName, e);
+        }
+    }
+
+    public Path directory(String runName) {
+        return baseDir.resolve(runName);
+    }
+}

--- a/apps/worker/src/test/java/com/tr1l/worker/reliability/ai/ContextSource.java
+++ b/apps/worker/src/test/java/com/tr1l/worker/reliability/ai/ContextSource.java
@@ -1,0 +1,27 @@
+package com.tr1l.worker.reliability.ai;
+
+import java.util.Objects;
+
+// 컨텍스트 조각 정의
+public record ContextSource(
+        String id,
+        String title,
+        String classpathLocation,
+        String content
+) {
+    public ContextSource {
+        id = requireText(id, "id");
+        title = requireText(title, "title");
+        classpathLocation = requireText(classpathLocation, "classpathLocation");
+        content = requireText(content, "content");
+    }
+
+    // 필수값 방어
+    private static String requireText(String value, String fieldName) {
+        String trimmed = Objects.requireNonNull(value, fieldName + " is required").trim();
+        if (trimmed.isEmpty()) {
+            throw new IllegalArgumentException(fieldName + " is blank");
+        }
+        return trimmed;
+    }
+}

--- a/apps/worker/src/test/java/com/tr1l/worker/reliability/ai/GeneratedInvariantBatchEvaluation.java
+++ b/apps/worker/src/test/java/com/tr1l/worker/reliability/ai/GeneratedInvariantBatchEvaluation.java
@@ -1,0 +1,14 @@
+package com.tr1l.worker.reliability.ai;
+
+import java.util.List;
+
+// 후보 묶음 평가 요약
+public record GeneratedInvariantBatchEvaluation(
+        List<GeneratedInvariantEvaluation> evaluations,
+        int totalCandidates,
+        int activeCandidateCount,
+        int reviewRequiredCount,
+        int rejectCount,
+        double averageScore
+) {
+}

--- a/apps/worker/src/test/java/com/tr1l/worker/reliability/ai/GeneratedInvariantCandidate.java
+++ b/apps/worker/src/test/java/com/tr1l/worker/reliability/ai/GeneratedInvariantCandidate.java
@@ -1,0 +1,74 @@
+package com.tr1l.worker.reliability.ai;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Objects;
+import java.util.Set;
+
+// 생성 후보 스키마 정의
+public record GeneratedInvariantCandidate(
+        @JsonProperty("id")
+        String id,
+        @JsonProperty("category")
+        String category,
+        @JsonProperty("description")
+        String description,
+        @JsonProperty("scope")
+        String scope,
+        @JsonProperty("sql_check")
+        String sqlCheck,
+        @JsonProperty("violated_by")
+        String violatedBy,
+        @JsonProperty("severity")
+        String severity
+) {
+    private static final Set<String> ALLOWED_CATEGORIES = Set.of(
+            "state_consistency",
+            "count_consistency",
+            "temporal",
+            "referential"
+    );
+    private static final Set<String> ALLOWED_SCOPES = Set.of(
+            "always",
+            "rerun_after_crash",
+            "step_complete"
+    );
+    private static final Set<String> ALLOWED_SEVERITIES = Set.of(
+            "critical",
+            "major",
+            "minor"
+    );
+
+    public GeneratedInvariantCandidate {
+        id = requireText(id, "id");
+        category = requireAllowed(category, "category", ALLOWED_CATEGORIES);
+        description = requireText(description, "description");
+        scope = requireAllowed(scope, "scope", ALLOWED_SCOPES);
+        sqlCheck = requireText(sqlCheck, "sqlCheck");
+        violatedBy = requireText(violatedBy, "violatedBy");
+        severity = requireAllowed(severity, "severity", ALLOWED_SEVERITIES);
+    }
+
+    // cross db 후보 판별
+    public boolean crossDb() {
+        return sqlCheck.contains("MongoDB") || sqlCheck.contains("cross-db");
+    }
+
+    // 필수값 방어
+    private static String requireText(String value, String fieldName) {
+        String trimmed = Objects.requireNonNull(value, fieldName + " is required").trim();
+        if (trimmed.isEmpty()) {
+            throw new IllegalArgumentException(fieldName + " is blank");
+        }
+        return trimmed;
+    }
+
+    // 허용값 방어
+    private static String requireAllowed(String value, String fieldName, Set<String> allowedValues) {
+        String trimmed = requireText(value, fieldName);
+        if (!allowedValues.contains(trimmed)) {
+            throw new IllegalArgumentException(fieldName + " is not allowed: " + trimmed);
+        }
+        return trimmed;
+    }
+}

--- a/apps/worker/src/test/java/com/tr1l/worker/reliability/ai/GeneratedInvariantEvaluation.java
+++ b/apps/worker/src/test/java/com/tr1l/worker/reliability/ai/GeneratedInvariantEvaluation.java
@@ -1,0 +1,20 @@
+package com.tr1l.worker.reliability.ai;
+
+// 후보 단건 평가 결과
+public record GeneratedInvariantEvaluation(
+        String invariantId,
+        int formatScore,
+        int sqlExecutableScore,
+        int semanticAlignmentScore,
+        int scenarioLinkageScore,
+        int noveltyScore,
+        int totalScore,
+        boolean sqlExecutable,
+        boolean semanticallyAligned,
+        boolean scenarioLinked,
+        boolean novelAgainstActive,
+        String matchedActiveInvariantId,
+        double noveltySimilarity,
+        GeneratedInvariantPromotionDecision decision
+) {
+}

--- a/apps/worker/src/test/java/com/tr1l/worker/reliability/ai/GeneratedInvariantParser.java
+++ b/apps/worker/src/test/java/com/tr1l/worker/reliability/ai/GeneratedInvariantParser.java
@@ -12,7 +12,7 @@ import java.util.regex.Pattern;
 
 // 생성 응답 파싱 전용
 public final class GeneratedInvariantParser {
-    private static final Pattern CODE_FENCE = Pattern.compile("^```(?:json)?\\s*(.*?)\\s*```$", Pattern.DOTALL);
+    private static final Pattern CODE_FENCE = Pattern.compile("```(?:json)?\\s*(.*?)\\s*```", Pattern.DOTALL);
 
     private final ReliabilityResourceLoader loader = new ReliabilityResourceLoader();
 
@@ -39,7 +39,7 @@ public final class GeneratedInvariantParser {
         }
 
         Matcher matcher = CODE_FENCE.matcher(trimmed);
-        if (matcher.matches()) {
+        if (matcher.find()) {
             return matcher.group(1).trim();
         }
         return trimmed;

--- a/apps/worker/src/test/java/com/tr1l/worker/reliability/ai/GeneratedInvariantParser.java
+++ b/apps/worker/src/test/java/com/tr1l/worker/reliability/ai/GeneratedInvariantParser.java
@@ -1,0 +1,47 @@
+package com.tr1l.worker.reliability.ai;
+
+import com.tr1l.worker.reliability.support.ReliabilityObjectMappers;
+import com.tr1l.worker.reliability.support.ReliabilityResourceLoader;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+// 생성 응답 파싱 전용
+public final class GeneratedInvariantParser {
+    private static final Pattern CODE_FENCE = Pattern.compile("^```(?:json)?\\s*(.*?)\\s*```$", Pattern.DOTALL);
+
+    private final ReliabilityResourceLoader loader = new ReliabilityResourceLoader();
+
+    public List<GeneratedInvariantCandidate> loadFromResource(String classpathLocation) {
+        return parse(loader.loadText(classpathLocation));
+    }
+
+    public List<GeneratedInvariantCandidate> parse(String raw) {
+        String cleaned = stripCodeFence(raw);
+        try {
+            GeneratedInvariantCandidate[] parsed =
+                    ReliabilityObjectMappers.json().readValue(cleaned, GeneratedInvariantCandidate[].class);
+            return Arrays.asList(parsed);
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to parse generated invariant response", e);
+        }
+    }
+
+    // 코드펜스 제거
+    private String stripCodeFence(String raw) {
+        String trimmed = Objects.requireNonNull(raw, "raw is required").trim();
+        if (trimmed.isEmpty()) {
+            throw new IllegalArgumentException("raw is blank");
+        }
+
+        Matcher matcher = CODE_FENCE.matcher(trimmed);
+        if (matcher.matches()) {
+            return matcher.group(1).trim();
+        }
+        return trimmed;
+    }
+}

--- a/apps/worker/src/test/java/com/tr1l/worker/reliability/ai/GeneratedInvariantPromotionDecision.java
+++ b/apps/worker/src/test/java/com/tr1l/worker/reliability/ai/GeneratedInvariantPromotionDecision.java
@@ -1,0 +1,8 @@
+package com.tr1l.worker.reliability.ai;
+
+// 승격 판정 정의
+public enum GeneratedInvariantPromotionDecision {
+    ACTIVE_CANDIDATE,
+    REVIEW_REQUIRED,
+    REJECT
+}

--- a/apps/worker/src/test/java/com/tr1l/worker/reliability/ai/GeneratedInvariantScorer.java
+++ b/apps/worker/src/test/java/com/tr1l/worker/reliability/ai/GeneratedInvariantScorer.java
@@ -1,0 +1,210 @@
+package com.tr1l.worker.reliability.ai;
+
+import com.tr1l.worker.reliability.invariant.InvariantDefinition;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+// generated 후보 점수화 전용
+public final class GeneratedInvariantScorer {
+    private static final int FORMAT_SCORE = 20;
+    private static final int SQL_EXECUTABLE_SCORE = 25;
+    private static final int SEMANTIC_ALIGNMENT_SCORE = 25;
+    private static final int SCENARIO_LINKAGE_SCORE = 15;
+    private static final int NOVELTY_SCORE = 15;
+    private static final Pattern TOKEN_SPLIT = Pattern.compile("[^\\p{L}\\p{Nd}]+");
+    private static final double DUPLICATE_THRESHOLD = 0.25d;
+
+    public GeneratedInvariantBatchEvaluation evaluate(
+            List<GeneratedInvariantCandidate> candidates,
+            List<InvariantDefinition> activeInvariants
+    ) {
+        List<GeneratedInvariantEvaluation> evaluations = candidates.stream()
+                .map(candidate -> evaluateOne(candidate, activeInvariants))
+                .toList();
+
+        int totalCandidates = evaluations.size();
+        int activeCandidateCount = (int) evaluations.stream()
+                .filter(evaluation -> evaluation.decision() == GeneratedInvariantPromotionDecision.ACTIVE_CANDIDATE)
+                .count();
+        int reviewRequiredCount = (int) evaluations.stream()
+                .filter(evaluation -> evaluation.decision() == GeneratedInvariantPromotionDecision.REVIEW_REQUIRED)
+                .count();
+        int rejectCount = (int) evaluations.stream()
+                .filter(evaluation -> evaluation.decision() == GeneratedInvariantPromotionDecision.REJECT)
+                .count();
+        double averageScore = evaluations.stream()
+                .mapToInt(GeneratedInvariantEvaluation::totalScore)
+                .average()
+                .orElse(0d);
+
+        return new GeneratedInvariantBatchEvaluation(
+                evaluations,
+                totalCandidates,
+                activeCandidateCount,
+                reviewRequiredCount,
+                rejectCount,
+                averageScore
+        );
+    }
+
+    // 단건 평가
+    private GeneratedInvariantEvaluation evaluateOne(
+            GeneratedInvariantCandidate candidate,
+            List<InvariantDefinition> activeInvariants
+    ) {
+        boolean sqlExecutable = isSqlExecutable(candidate);
+        boolean semanticallyAligned = isSemanticallyAligned(candidate);
+        boolean scenarioLinked = isScenarioLinked(candidate);
+        NoveltyMatch noveltyMatch = findNoveltyMatch(candidate, activeInvariants);
+
+        int formatScore = FORMAT_SCORE;
+        int sqlExecutableScore = sqlExecutable ? SQL_EXECUTABLE_SCORE : 0;
+        int semanticAlignmentScore = semanticallyAligned ? SEMANTIC_ALIGNMENT_SCORE : 0;
+        int scenarioLinkageScore = scenarioLinked ? SCENARIO_LINKAGE_SCORE : 0;
+        int noveltyScore = noveltyMatch.novel() ? NOVELTY_SCORE : 0;
+        int totalScore = formatScore + sqlExecutableScore + semanticAlignmentScore + scenarioLinkageScore + noveltyScore;
+
+        GeneratedInvariantPromotionDecision decision = decide(totalScore, sqlExecutable, noveltyMatch.novel());
+
+        return new GeneratedInvariantEvaluation(
+                candidate.id(),
+                formatScore,
+                sqlExecutableScore,
+                semanticAlignmentScore,
+                scenarioLinkageScore,
+                noveltyScore,
+                totalScore,
+                sqlExecutable,
+                semanticallyAligned,
+                scenarioLinked,
+                noveltyMatch.novel(),
+                noveltyMatch.matchedActiveId(),
+                noveltyMatch.similarity(),
+                decision
+        );
+    }
+
+    // 실행 가능 판정
+    private boolean isSqlExecutable(GeneratedInvariantCandidate candidate) {
+        String sql = candidate.sqlCheck().trim();
+        String normalized = sql.toUpperCase(Locale.ROOT);
+
+        if (candidate.crossDb()) {
+            return sql.contains("cross-db") || sql.contains("MongoDB");
+        }
+
+        return normalized.startsWith("SELECT")
+                && normalized.contains("FROM")
+                && !normalized.contains("...");
+    }
+
+    // 의미 일치 판정
+    private boolean isSemanticallyAligned(GeneratedInvariantCandidate candidate) {
+        String description = normalizeText(candidate.description());
+        String sql = candidate.sqlCheck().toUpperCase(Locale.ROOT);
+
+        return switch (candidate.category()) {
+            case "count_consistency" ->
+                    (description.contains("수") || description.contains("count"))
+                            && sql.contains("COUNT(");
+            case "state_consistency" ->
+                    (description.contains("최대") || description.contains("중복"))
+                            && sql.contains("GROUP BY")
+                            && sql.contains("HAVING");
+            case "temporal" ->
+                    description.contains("재실행")
+                            && (sql.contains("LEASE_UNTIL") || sql.contains("NOW()") || sql.contains("PROCESSING"));
+            case "referential" ->
+                    (description.contains("mongodb") || sql.contains("MONGODB") || candidate.crossDb())
+                            && (description.contains("workid") || sql.contains("WORK_ID") || sql.contains("WORKID"));
+            default -> false;
+        };
+    }
+
+    // 시나리오 연결 판정
+    private boolean isScenarioLinked(GeneratedInvariantCandidate candidate) {
+        String violatedBy = normalizeText(candidate.violatedBy());
+        if (violatedBy.isBlank()) {
+            return false;
+        }
+
+        return violatedBy.contains("중복")
+                || violatedBy.contains("재실행")
+                || violatedBy.contains("processing")
+                || violatedBy.contains("snapshot")
+                || violatedBy.contains("mongo")
+                || violatedBy.contains("lease")
+                || violatedBy.contains("partial")
+                || violatedBy.contains("수렴");
+    }
+
+    // 신규성 판정
+    private NoveltyMatch findNoveltyMatch(
+            GeneratedInvariantCandidate candidate,
+            List<InvariantDefinition> activeInvariants
+    ) {
+        Set<String> candidateTokens = tokenize(candidate.description());
+
+        return activeInvariants.stream()
+                .filter(active -> candidate.category().equals(active.category()))
+                .map(active -> new NoveltyMatch(
+                        active.id(),
+                        jaccard(candidateTokens, tokenize(active.description()))
+                ))
+                .max(Comparator.comparingDouble(NoveltyMatch::similarity))
+                .map(match -> match.similarity() >= DUPLICATE_THRESHOLD
+                        ? new NoveltyMatch(false, match.matchedActiveId(), match.similarity())
+                        : new NoveltyMatch(true, null, match.similarity()))
+                .orElseGet(() -> new NoveltyMatch(true, null, 0d));
+    }
+
+    // 최종 판정
+    private GeneratedInvariantPromotionDecision decide(int totalScore, boolean sqlExecutable, boolean novel) {
+        if (!sqlExecutable || totalScore < 60) {
+            return GeneratedInvariantPromotionDecision.REJECT;
+        }
+        if (totalScore >= 85 && novel) {
+            return GeneratedInvariantPromotionDecision.ACTIVE_CANDIDATE;
+        }
+        return GeneratedInvariantPromotionDecision.REVIEW_REQUIRED;
+    }
+
+    // 공백 정리
+    private String normalizeText(String text) {
+        return text == null ? "" : text.toLowerCase(Locale.ROOT).replaceAll("\\s+", " ").trim();
+    }
+
+    // 토큰 분리
+    private Set<String> tokenize(String text) {
+        return TOKEN_SPLIT.splitAsStream(normalizeText(text))
+                .filter(token -> !token.isBlank())
+                .collect(Collectors.toSet());
+    }
+
+    // 유사도 계산
+    private double jaccard(Set<String> left, Set<String> right) {
+        if (left.isEmpty() || right.isEmpty()) {
+            return 0d;
+        }
+
+        long intersection = left.stream().filter(right::contains).count();
+        long union = left.size() + right.size() - intersection;
+        return union == 0 ? 0d : (double) intersection / union;
+    }
+
+    // 신규성 비교 결과
+    private record NoveltyMatch(
+            boolean novel,
+            String matchedActiveId,
+            double similarity
+    ) {
+        private NoveltyMatch(String matchedActiveId, double similarity) {
+            this(false, matchedActiveId, similarity);
+        }
+    }
+}

--- a/apps/worker/src/test/java/com/tr1l/worker/reliability/ai/Job1InvariantContextPack.java
+++ b/apps/worker/src/test/java/com/tr1l/worker/reliability/ai/Job1InvariantContextPack.java
@@ -1,0 +1,35 @@
+package com.tr1l.worker.reliability.ai;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+// Job1 입력 묶음 정의
+public record Job1InvariantContextPack(
+        String packId,
+        List<ContextSource> sources
+) {
+    public Job1InvariantContextPack {
+        packId = requireText(packId, "packId");
+        sources = List.copyOf(Objects.requireNonNull(sources, "sources is required"));
+        if (sources.isEmpty()) {
+            throw new IllegalArgumentException("sources is empty");
+        }
+    }
+
+    // 사용자 프롬프트 렌더링
+    public String renderForUserPrompt() {
+        return sources.stream()
+                .map(source -> "=== " + source.title() + " ===\n" + source.content().trim())
+                .collect(Collectors.joining("\n\n"));
+    }
+
+    // 필수값 방어
+    private static String requireText(String value, String fieldName) {
+        String trimmed = Objects.requireNonNull(value, fieldName + " is required").trim();
+        if (trimmed.isEmpty()) {
+            throw new IllegalArgumentException(fieldName + " is blank");
+        }
+        return trimmed;
+    }
+}

--- a/apps/worker/src/test/java/com/tr1l/worker/reliability/ai/Job1InvariantContextPackBuilder.java
+++ b/apps/worker/src/test/java/com/tr1l/worker/reliability/ai/Job1InvariantContextPackBuilder.java
@@ -1,0 +1,37 @@
+package com.tr1l.worker.reliability.ai;
+
+import com.tr1l.worker.reliability.support.ReliabilityResourceLoader;
+
+import java.util.List;
+
+// Job1 컨텍스트 묶음 조립
+public final class Job1InvariantContextPackBuilder {
+    private static final String BASE_PATH = "reliability/ai/context/job1/";
+
+    private final ReliabilityResourceLoader loader = new ReliabilityResourceLoader();
+
+    public Job1InvariantContextPack build() {
+        return new Job1InvariantContextPack(
+                "job1-invariant-generator-mvp",
+                List.of(
+                        load("job1-billing-targets-ddl", "billing_targets 테이블 DDL", "01_billing_targets_ddl.sql"),
+                        load("job1-billing-work-ddl", "billing_work 테이블 DDL", "02_billing_work_ddl.sql"),
+                        load("job1-billing-snapshot-schema", "Mongo billing_snapshot 스키마", "03_billing_snapshot_schema.json"),
+                        load("job1-step3-core-flow", "Step3 핵심 코드", "04_step3_core_flow.txt"),
+                        load("job1-state-transitions", "상태 전이 규칙", "05_state_transitions.txt"),
+                        load("job1-rerun-design-intent", "rerun safe 설계 의도", "06_rerun_design_intent.txt")
+                )
+        );
+    }
+
+    // classpath 리소스 적재
+    private ContextSource load(String id, String title, String fileName) {
+        String classpathLocation = BASE_PATH + fileName;
+        return new ContextSource(
+                id,
+                title,
+                classpathLocation,
+                loader.loadText(classpathLocation)
+        );
+    }
+}

--- a/apps/worker/src/test/java/com/tr1l/worker/reliability/ai/Job1InvariantPrompt.java
+++ b/apps/worker/src/test/java/com/tr1l/worker/reliability/ai/Job1InvariantPrompt.java
@@ -1,0 +1,23 @@
+package com.tr1l.worker.reliability.ai;
+
+import java.util.Objects;
+
+// LLM 요청 초안 정의
+public record Job1InvariantPrompt(
+        String systemPrompt,
+        String userPrompt
+) {
+    public Job1InvariantPrompt {
+        systemPrompt = requireText(systemPrompt, "systemPrompt");
+        userPrompt = requireText(userPrompt, "userPrompt");
+    }
+
+    // 필수값 방어
+    private static String requireText(String value, String fieldName) {
+        String trimmed = Objects.requireNonNull(value, fieldName + " is required").trim();
+        if (trimmed.isEmpty()) {
+            throw new IllegalArgumentException(fieldName + " is blank");
+        }
+        return trimmed;
+    }
+}

--- a/apps/worker/src/test/java/com/tr1l/worker/reliability/ai/Job1InvariantPromptComposer.java
+++ b/apps/worker/src/test/java/com/tr1l/worker/reliability/ai/Job1InvariantPromptComposer.java
@@ -1,0 +1,23 @@
+package com.tr1l.worker.reliability.ai;
+
+import com.tr1l.worker.reliability.support.ReliabilityResourceLoader;
+
+// 프롬프트 조립 전용
+public final class Job1InvariantPromptComposer {
+    private static final String SYSTEM_PROMPT_PATH = "reliability/ai/prompts/job1-invariant-generator-system.txt";
+
+    private final ReliabilityResourceLoader loader = new ReliabilityResourceLoader();
+
+    public Job1InvariantPrompt compose(Job1InvariantContextPack contextPack) {
+        String systemPrompt = loader.loadText(SYSTEM_PROMPT_PATH).trim();
+        String userPrompt = """
+                다음 컨텍스트를 읽고 Job1 Step3 rerun safe invariant 후보를 도출하라
+
+                %s
+
+                응답은 JSON 배열만 반환
+                """.formatted(contextPack.renderForUserPrompt()).trim();
+
+        return new Job1InvariantPrompt(systemPrompt, userPrompt);
+    }
+}

--- a/apps/worker/src/test/java/com/tr1l/worker/reliability/ai/OpenAiInvariantGenerationResult.java
+++ b/apps/worker/src/test/java/com/tr1l/worker/reliability/ai/OpenAiInvariantGenerationResult.java
@@ -1,0 +1,12 @@
+package com.tr1l.worker.reliability.ai;
+
+// OpenAI 응답 결과 묶음
+public record OpenAiInvariantGenerationResult(
+        String responseId,
+        String model,
+        String requestBody,
+        String responseBody,
+        String outputText,
+        OpenAiUsageSummary usage
+) {
+}

--- a/apps/worker/src/test/java/com/tr1l/worker/reliability/ai/OpenAiInvariantRuntimeConfig.java
+++ b/apps/worker/src/test/java/com/tr1l/worker/reliability/ai/OpenAiInvariantRuntimeConfig.java
@@ -1,0 +1,29 @@
+package com.tr1l.worker.reliability.ai;
+
+// OpenAI 호출 설정 묶음
+public record OpenAiInvariantRuntimeConfig(
+        String apiKey,
+        String baseUrl,
+        String model,
+        String reasoningEffort,
+        String runName
+) {
+    public static OpenAiInvariantRuntimeConfig fromEnvironment() {
+        return new OpenAiInvariantRuntimeConfig(
+                env("OPENAI_API_KEY", ""),
+                env("OPENAI_API_BASE_URL", "https://api.openai.com/v1"),
+                env("JOB1_AI_INVARIANT_OPENAI_MODEL", "gpt-5.4-mini"),
+                env("JOB1_AI_INVARIANT_REASONING_EFFORT", "low"),
+                env("JOB1_AI_INVARIANT_RUN_NAME", "live-job1-invariant-generator")
+        );
+    }
+
+    public boolean enabled() {
+        return apiKey != null && !apiKey.isBlank();
+    }
+
+    private static String env(String key, String defaultValue) {
+        String value = System.getenv(key);
+        return value == null || value.isBlank() ? defaultValue : value;
+    }
+}

--- a/apps/worker/src/test/java/com/tr1l/worker/reliability/ai/OpenAiResponsesInvariantGenerator.java
+++ b/apps/worker/src/test/java/com/tr1l/worker/reliability/ai/OpenAiResponsesInvariantGenerator.java
@@ -1,0 +1,185 @@
+package com.tr1l.worker.reliability.ai;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.tr1l.worker.reliability.support.ReliabilityObjectMappers;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+
+// Responses API 호출기
+public final class OpenAiResponsesInvariantGenerator {
+    private final HttpClient httpClient = HttpClient.newHttpClient();
+    private final OpenAiInvariantRuntimeConfig config;
+
+    public OpenAiResponsesInvariantGenerator(OpenAiInvariantRuntimeConfig config) {
+        this.config = config;
+    }
+
+    public long countInputTokens(Job1InvariantPrompt prompt) {
+        ObjectNode requestBody = baseRequestBody(prompt);
+        String responseBody = send("/responses/input_tokens", requestBody);
+
+        try {
+            JsonNode root = ReliabilityObjectMappers.json().readTree(responseBody);
+            return root.path("input_tokens").asLong(-1);
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to parse input token count response", e);
+        }
+    }
+
+    public OpenAiInvariantGenerationResult generate(Job1InvariantPrompt prompt) {
+        ObjectNode requestBody = baseRequestBody(prompt);
+        requestBody.put("max_output_tokens", 3000);
+        requestBody.set("text", buildStructuredOutputFormat());
+
+        String requestBodyText = toPrettyJson(requestBody);
+        String responseBody = send("/responses", requestBody);
+
+        try {
+            JsonNode root = ReliabilityObjectMappers.json().readTree(responseBody);
+            return new OpenAiInvariantGenerationResult(
+                    root.path("id").asText(""),
+                    root.path("model").asText(config.model()),
+                    requestBodyText,
+                    toPrettyJson(root),
+                    extractOutputText(root),
+                    new OpenAiUsageSummary(
+                            root.path("usage").path("input_tokens").asLong(-1),
+                            root.path("usage").path("output_tokens").asLong(-1),
+                            root.path("usage").path("total_tokens").asLong(-1)
+                    )
+            );
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to parse OpenAI responses payload", e);
+        }
+    }
+
+    // 공통 요청 바디
+    private ObjectNode baseRequestBody(Job1InvariantPrompt prompt) {
+        ObjectNode requestBody = ReliabilityObjectMappers.json().createObjectNode();
+        requestBody.put("model", config.model());
+        requestBody.put("store", false);
+
+        ObjectNode reasoning = requestBody.putObject("reasoning");
+        reasoning.put("effort", config.reasoningEffort());
+
+        ArrayNode input = requestBody.putArray("input");
+        ObjectNode systemMessage = input.addObject();
+        systemMessage.put("role", "system");
+        systemMessage.put("content", prompt.systemPrompt());
+
+        ObjectNode userMessage = input.addObject();
+        userMessage.put("role", "user");
+        userMessage.put("content", prompt.userPrompt());
+        return requestBody;
+    }
+
+    // structured output 정의
+    private ObjectNode buildStructuredOutputFormat() {
+        ObjectNode text = ReliabilityObjectMappers.json().createObjectNode();
+        ObjectNode format = text.putObject("format");
+        format.put("type", "json_schema");
+        format.put("name", "job1_invariant_candidates");
+        format.put("strict", true);
+
+        ObjectNode schema = format.putObject("schema");
+        schema.put("type", "array");
+
+        ObjectNode item = schema.putObject("items");
+        item.put("type", "object");
+
+        ObjectNode properties = item.putObject("properties");
+        stringProperty(properties, "id", "invariant id");
+        enumProperty(properties, "category", "state_consistency", "count_consistency", "temporal", "referential");
+        stringProperty(properties, "description", "description");
+        enumProperty(properties, "scope", "always", "rerun_after_crash", "step_complete");
+        stringProperty(properties, "sql_check", "sql check");
+        stringProperty(properties, "violated_by", "violation scenario");
+        enumProperty(properties, "severity", "critical", "major", "minor");
+
+        ArrayNode required = item.putArray("required");
+        required.add("id");
+        required.add("category");
+        required.add("description");
+        required.add("scope");
+        required.add("sql_check");
+        required.add("violated_by");
+        required.add("severity");
+        item.put("additionalProperties", false);
+
+        return text;
+    }
+
+    // 문자열 속성 정의
+    private void stringProperty(ObjectNode properties, String name, String description) {
+        ObjectNode property = properties.putObject(name);
+        property.put("type", "string");
+        property.put("description", description);
+    }
+
+    // enum 속성 정의
+    private void enumProperty(ObjectNode properties, String name, String... values) {
+        ObjectNode property = properties.putObject(name);
+        property.put("type", "string");
+        ArrayNode enumValues = property.putArray("enum");
+        for (String value : values) {
+            enumValues.add(value);
+        }
+    }
+
+    // 응답 전송
+    private String send(String path, JsonNode requestBody) {
+        try {
+            HttpRequest request = HttpRequest.newBuilder(URI.create(config.baseUrl() + path))
+                    .header("Authorization", "Bearer " + config.apiKey())
+                    .header("Content-Type", "application/json")
+                    .POST(HttpRequest.BodyPublishers.ofString(toPrettyJson(requestBody), StandardCharsets.UTF_8))
+                    .build();
+
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+            if (response.statusCode() >= 400) {
+                throw new IllegalStateException("OpenAI API request failed: status=" + response.statusCode() + " body=" + response.body());
+            }
+            return response.body();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Failed to call OpenAI responses API", e);
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to call OpenAI responses API", e);
+        }
+    }
+
+    // 텍스트 추출
+    private String extractOutputText(JsonNode root) {
+        String outputText = root.path("output_text").asText("");
+        if (!outputText.isBlank()) {
+            return outputText;
+        }
+
+        for (JsonNode outputItem : root.path("output")) {
+            for (JsonNode contentItem : outputItem.path("content")) {
+                if ("output_text".equals(contentItem.path("type").asText())
+                        && !contentItem.path("text").asText("").isBlank()) {
+                    return contentItem.path("text").asText();
+                }
+            }
+        }
+
+        throw new IllegalStateException("OpenAI response does not contain output_text");
+    }
+
+    // json pretty 출력
+    private String toPrettyJson(Object value) {
+        try {
+            return ReliabilityObjectMappers.json().writeValueAsString(value);
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to serialize JSON payload", e);
+        }
+    }
+}

--- a/apps/worker/src/test/java/com/tr1l/worker/reliability/ai/OpenAiUsageSummary.java
+++ b/apps/worker/src/test/java/com/tr1l/worker/reliability/ai/OpenAiUsageSummary.java
@@ -1,0 +1,9 @@
+package com.tr1l.worker.reliability.ai;
+
+// 토큰 사용량 요약
+public record OpenAiUsageSummary(
+        long inputTokens,
+        long outputTokens,
+        long totalTokens
+) {
+}

--- a/apps/worker/src/test/resources/reliability/ai/context/job1/01_billing_targets_ddl.sql
+++ b/apps/worker/src/test/resources/reliability/ai/context/job1/01_billing_targets_ddl.sql
@@ -1,0 +1,40 @@
+CREATE TABLE IF NOT EXISTS billing_targets
+(
+    billing_month            date           NOT NULL,
+    user_id                  bigint         NOT NULL,
+    created_at               timestamp      NOT NULL DEFAULT now(),
+    user_name                varchar(100)   NOT NULL,
+    user_birth_date          date           NOT NULL,
+    recipient_email          varchar(150)   NOT NULL,
+    recipient_phone          varchar(150)   NOT NULL,
+    plan_name                varchar(100)   NOT NULL,
+    plan_monthly_price       bigint         NOT NULL,
+    network_type_name        varchar(10)    NOT NULL,
+    data_billing_type_code   varchar(10)    NOT NULL,
+    data_billing_type_name   varchar(50)    NOT NULL,
+    included_data_mb         bigint         NOT NULL,
+    excess_charge_per_mb     numeric(12, 6) NOT NULL,
+    used_data_mb             bigint         NOT NULL,
+    has_contract             boolean        NOT NULL default false,
+    contract_rate            numeric(6, 5)  NOT NULL,
+    contract_duration_months integer        NOT NULL,
+    soldier_eligible         boolean        NOT NULL default false,
+    welfare_eligible         boolean        NOT NULL default false,
+    welfare_code             varchar(20),
+    welfare_name             varchar(50)    NOT NULL,
+    welfare_rate             numeric(6, 5)  NOT NULL,
+    welfare_cap_amount       bigint         NOT NULL default 0,
+    from_time                varchar(2)     NULL,
+    to_time                  varchar(2)     NULL,
+    day_time                 varchar(2)     NULL,
+    attempt_count            int                     default 0,
+    send_status              varchar(50)    NOT NULL default 'INIT',
+    s3_url_jsonb             jsonb          NULL     default '[]'::jsonb,
+    send_option_jsonb        jsonb          NULL     default '[]'::jsonb,
+    options_jsonb            jsonb          NULL     default '[]'::jsonb,
+
+    CONSTRAINT pk_billing_targets PRIMARY KEY (billing_month, user_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_billing_targets_month_user
+    ON billing_targets (billing_month, user_id);

--- a/apps/worker/src/test/resources/reliability/ai/context/job1/02_billing_work_ddl.sql
+++ b/apps/worker/src/test/resources/reliability/ai/context/job1/02_billing_work_ddl.sql
@@ -1,0 +1,23 @@
+CREATE TABLE IF NOT EXISTS billing_work
+(
+    user_id           BIGINT      NOT NULL,
+    billing_month_day DATE        NOT NULL,
+    billing_id        varchar(64),
+    error_code        varchar(64),
+    error_message     text,
+    claimed_by        varchar(64),
+    lease_until       timestamptz NULL,
+    last_error        text        NULL,
+    status            varchar(30) NOT NULL,
+    attempt_count     INTEGER     NOT NULL DEFAULT 0,
+    created_at        timestamp   NOT NULL DEFAULT now(),
+    updated_at        timestamp   NOT NULL DEFAULT now(),
+
+    PRIMARY KEY (billing_month_day, user_id),
+
+    CONSTRAINT ck_billing_work_status
+        CHECK (status IN ('TARGET', 'PROCESSING', 'CALCULATED', 'FAILED'))
+);
+
+CREATE INDEX IF NOT EXISTS ix_billing_work_month_status
+    ON billing_work (billing_month_day, status, user_id);

--- a/apps/worker/src/test/resources/reliability/ai/context/job1/03_billing_snapshot_schema.json
+++ b/apps/worker/src/test/resources/reliability/ai/context/job1/03_billing_snapshot_schema.json
@@ -1,0 +1,39 @@
+{
+  "collection": "billing_snapshot",
+  "documentKey": {
+    "_id": "billingId"
+  },
+  "requiredFields": [
+    {
+      "name": "workId",
+      "type": "string",
+      "description": "billing_work 와 연결되는 멱등 키"
+    },
+    {
+      "name": "billingMonth",
+      "type": "string",
+      "format": "YYYY-MM-DD"
+    },
+    {
+      "name": "userId",
+      "type": "long"
+    },
+    {
+      "name": "status",
+      "type": "string"
+    },
+    {
+      "name": "issuedAt",
+      "type": "instant"
+    },
+    {
+      "name": "payload",
+      "type": "document"
+    }
+  ],
+  "writeBehavior": {
+    "operation": "bulk upsert",
+    "collectionName": "billing_snapshot",
+    "afterSaveFailureHook": "fail-after-snapshot-save"
+  }
+}

--- a/apps/worker/src/test/resources/reliability/ai/context/job1/04_step3_core_flow.txt
+++ b/apps/worker/src/test/resources/reliability/ai/context/job1/04_step3_core_flow.txt
@@ -1,0 +1,28 @@
+File apps/worker/src/main/resources/sql/job1/step3/target/01_claim_upsert.sql
+- billing_work 에서 TARGET 또는 lease 만료 PROCESSING 선점
+- FOR UPDATE SKIP LOCKED 사용
+- status 를 PROCESSING 으로 변경
+- attempt_count 증가
+
+핵심 SQL 조각
+WITH cte AS (
+  SELECT billing_month_day, user_id
+  FROM billing_work
+  WHERE billing_month_day = :billingMonthDay
+    AND (
+      status = 'TARGET'
+      OR (status = 'PROCESSING' AND lease_until IS NOT NULL AND lease_until < :now)
+    )
+  ORDER BY user_id
+  LIMIT :limit FOR UPDATE SKIP LOCKED
+)
+
+File apps/worker/src/main/java/com/tr1l/worker/batch/calculatejob/step/step3/CalculateAndSnapshotWriter.java
+- snapshotSavePort.saveAll(billings)
+- statusPort.markCalculatedAll(calculatedUpdates now)
+- statusPort.markFailedAll(failedUpdates now)
+
+File contexts/billing/src/main/java/com/tr1l/billing/adapter/out/persistence/mongo/MongoBillingSnapshotSaveAdapter.java
+- bulk.execute()
+- maybeFailAfterSnapshotSave()
+- Mongo 저장 직후 예외 주입 가능

--- a/apps/worker/src/test/resources/reliability/ai/context/job1/05_state_transitions.txt
+++ b/apps/worker/src/test/resources/reliability/ai/context/job1/05_state_transitions.txt
@@ -1,0 +1,13 @@
+기본 상태 전이
+TARGET -> PROCESSING
+PROCESSING -> CALCULATED
+PROCESSING -> FAILED
+
+재실행 규칙
+- lease_until 안쪽 PROCESSING 은 정상 상태
+- lease_until 지난 PROCESSING 은 재선점 대상
+- 재실행 완료 뒤 stale PROCESSING 잔존 금지
+
+식별 규칙
+- workId 는 billingMonthDay:userId 형태
+- billing_snapshot.workId 는 billing_work 와 연결 키

--- a/apps/worker/src/test/resources/reliability/ai/context/job1/06_rerun_design_intent.txt
+++ b/apps/worker/src/test/resources/reliability/ai/context/job1/06_rerun_design_intent.txt
@@ -1,0 +1,6 @@
+Job1 rerun safe 설계 의도
+- 같은 cutoff 로 다시 돌려도 billing_targets 수는 흔들리면 안 됨
+- 같은 billing_month_day user_id 조합의 billing_work 는 중복되면 안 됨
+- Mongo snapshot 저장만 끝나고 PG 상태 반영이 끊길 수 있음
+- 이런 partial success 도 재실행 뒤에는 CALCULATED 와 snapshot 상태가 다시 맞아야 함
+- 최종 완료 뒤에는 stuck PROCESSING 이 남아 있으면 안 됨

--- a/apps/worker/src/test/resources/reliability/ai/prompts/job1-invariant-generator-system.txt
+++ b/apps/worker/src/test/resources/reliability/ai/prompts/job1-invariant-generator-system.txt
@@ -1,0 +1,30 @@
+너는 분산 시스템 데이터 일관성 검증 전문가다
+
+주어진 스키마 코드 상태 전이 규칙을 읽고 Job1 Step3 가 올바르게 동작할 때 반드시 성립해야 하는 invariant 후보를 도출하라
+
+출력 규칙
+1. JSON 배열만 출력
+2. 각 항목은 아래 필드를 모두 포함
+   - "id"
+   - "category"
+   - "description"
+   - "scope"
+   - "sql_check"
+   - "violated_by"
+   - "severity"
+3. category 허용값
+   - state_consistency
+   - count_consistency
+   - temporal
+   - referential
+4. scope 허용값
+   - always
+   - rerun_after_crash
+   - step_complete
+5. severity 허용값
+   - critical
+   - major
+   - minor
+6. PROCESSING 상태는 lease 기간 안에서는 일시적으로 허용될 수 있음
+7. 항상 성립 조건과 재실행 완료 뒤 성립 조건을 구분
+8. sql_check 는 PostgreSQL 또는 cross-db 확인 흐름으로 적기

--- a/apps/worker/src/test/resources/reliability/invariants/generated/job1-invariant-candidates.sample.json
+++ b/apps/worker/src/test/resources/reliability/invariants/generated/job1-invariant-candidates.sample.json
@@ -1,0 +1,38 @@
+[
+  {
+    "id": "INV-101",
+    "category": "count_consistency",
+    "description": "특정 billing_month_day 의 CALCULATED billing_work 수는 billing_targets 수를 넘으면 안 된다",
+    "scope": "step_complete",
+    "sql_check": "SELECT bw.billing_month_day FROM billing_work bw LEFT JOIN billing_targets bt ON bt.billing_month = bw.billing_month_day AND bt.user_id = bw.user_id WHERE bw.billing_month_day = :month GROUP BY bw.billing_month_day HAVING COUNT(*) FILTER (WHERE bw.status = 'CALCULATED') > COUNT(bt.user_id)",
+    "violated_by": "중복 work 생성 뒤 둘 다 CALCULATED 로 끝난 경우",
+    "severity": "critical"
+  },
+  {
+    "id": "INV-102",
+    "category": "state_consistency",
+    "description": "같은 billing_month_day 와 user_id 조합의 billing_work 는 최대 1개여야 한다",
+    "scope": "always",
+    "sql_check": "SELECT billing_month_day, user_id FROM billing_work WHERE billing_month_day = :month GROUP BY billing_month_day, user_id HAVING COUNT(*) > 1",
+    "violated_by": "work insert 경로가 멱등하지 않게 바뀐 경우",
+    "severity": "critical"
+  },
+  {
+    "id": "INV-103",
+    "category": "temporal",
+    "description": "재실행이 끝난 뒤에는 lease_until 이 지난 PROCESSING work 가 남아 있으면 안 된다",
+    "scope": "rerun_after_crash",
+    "sql_check": "SELECT user_id FROM billing_work WHERE billing_month_day = :month AND status = 'PROCESSING' AND lease_until < NOW()",
+    "violated_by": "재실행이 끝났는데 reclaim 되지 않은 PROCESSING 이 남은 경우",
+    "severity": "major"
+  },
+  {
+    "id": "INV-104",
+    "category": "referential",
+    "description": "CALCULATED 상태의 billing_work 는 MongoDB billing_snapshot 에 대응 workId 가 있어야 한다",
+    "scope": "rerun_after_crash",
+    "sql_check": "cross-db: SELECT work_id FROM billing_work WHERE billing_month_day = :month AND status = 'CALCULATED' THEN compare with MongoDB billing_snapshot.workId",
+    "violated_by": "Mongo 저장 전에 끊기거나 rerun 수렴이 누락된 경우",
+    "severity": "critical"
+  }
+]


### PR DESCRIPTION
## 📝작업 내용

이번 PR에서는 Job1 reliability 검증 흐름 안에 AI invariant generator MVP 범위를 한 단계 더 확장했습니다

기존 초안에서 끝내지 않고 아래 세 가지를 추가했습니다

- PR 리뷰 반영으로 코드펜스 파싱 보완
- generated 후보 점수화 기준 추가
- `gpt-5.4-mini` 기준 OpenAI Responses API live generation 경로 추가

아직 이 세션에서는 `OPENAI_API_KEY` 가 없어서 실제 live 응답 캡처까지는 못 했지만
키만 주어지면 raw request raw response normalized candidates metrics 파일을 바로 남길 수 있는 상태로 정리했습니다


<br/>

## 👀변경 사항

### 이번 PR에서 바뀐 것

| 구분 | 변경 내용 | 이유 |
| --- | --- | --- |
| parser | 코드펜스 정규식 앵커 제거와 `find()` 적용 | 설명 텍스트가 앞뒤에 붙은 LLM 응답도 읽기 위해 |
| scoring | 형식 20 SQL 실행 가능 25 의미 일치 25 시나리오 연결 15 신규성 15 점수화 추가 | generated 후보를 active 승격 기준으로 수치화하기 위해 |
| scoring | `ACTIVE_CANDIDATE` `REVIEW_REQUIRED` `REJECT` 판정 추가 | 사람이 보기 전에 후보를 1차 정리하기 위해 |
| live | `OpenAiResponsesInvariantGenerator` 추가 | OpenAI Responses API 실호출 경로를 만들기 위해 |
| model | 기본 모델을 `gpt-5.4-mini` 로 설정 | 반복 실험 가능한 비용과 속도를 맞추기 위해 |
| artifact | `build/job1-ai-invariant-results` 저장 경로 추가 | raw 응답과 평가 결과를 실제 캡처 파일로 남기기 위해 |
| test | scoring 계약 테스트와 live generation 테스트 추가 | 점수화 기준과 실호출 경로를 JUnit 에 고정하기 위해 |

### 흐름

```mermaid
flowchart LR
    A["Job1 컨텍스트 패키지"] --> B["프롬프트 조립"]
    B --> C["OpenAI Responses API gpt-5.4-mini"]
    C --> D["Generated invariant 파서"]
    D --> E["점수화 scorer"]
    E --> F["ACTIVE_CANDIDATE / REVIEW_REQUIRED / REJECT"]
    F --> G["artifact 저장"]

    classDef source fill:#E8F2FF,stroke:#4A78C2,color:#0F2557
    classDef process fill:#EEFBEA,stroke:#5C9C4B,color:#153B0E
    classDef verify fill:#FFF3E6,stroke:#D97706,color:#5B3411

    class A source
    class B,C,D,E,F process
    class G verify
```

### 테스트 개요

| 항목 | 내용 |
| --- | --- |
| 검증 대상 | Job1 AI invariant generator MVP 확장 범위 |
| 검증 목적 | 파서 안정성 보완과 generated 후보 점수화 기준 추가 그리고 OpenAI live 호출 경로 고정 |
| 파서 보완 범위 | 코드펜스 앞뒤 설명 텍스트 허용 |
| 점수화 기준 | 형식 20 SQL 25 의미 25 시나리오 15 신규성 15 |
| live 모델 | `gpt-5.4-mini` |
| live artifact 경로 | `apps/worker/build/job1-ai-invariant-results/live-job1-invariant-generator/` |
| scoring artifact 경로 | `apps/worker/build/job1-ai-invariant-results/sample-generated-invariant-score/generated-candidate-evaluation.json` |
| 실행 명령 | `./gradlew :apps:worker:test --tests com.tr1l.worker.reliability.Job1AiInvariantGeneratorContractTest --tests com.tr1l.worker.reliability.Job1AiInvariantScoringContractTest --tests com.tr1l.worker.reliability.Job1AiInvariantLiveGenerationTest --tests com.tr1l.worker.reliability.Job1ReliabilityResourceContractTest` |

### 실행 결과

| 테스트 | 결과 | 수치 |
| --- | --- | --- |
| `Job1AiInvariantGeneratorContractTest` | PASS | 6 / 6 |
| `Job1AiInvariantScoringContractTest` | PASS | 1 / 1 |
| `Job1AiInvariantLiveGenerationTest` | SKIP | 1 / 1  `OPENAI_API_KEY` 미설정 |
| `Job1ReliabilityResourceContractTest` | PASS | 4 / 4 |
| 전체 | PASS | 실행 11 / 11  skip 1 |

### generated 후보 점수화 결과

| invariant | 총점 | 판정 | 비고 |
| --- | ---: | --- | --- |
| `INV-101` | 100 | `ACTIVE_CANDIDATE` | 신규 count invariant |
| `INV-102` | 70 | `REVIEW_REQUIRED` | active `INV-001` 과 중복 |
| `INV-103` | 85 | `REVIEW_REQUIRED` | active `INV-002` 와 유사 |
| `INV-104` | 85 | `REVIEW_REQUIRED` | active `INV-003` 와 유사 |

요약 수치

| 항목 | 수치 |
| --- | ---: |
| totalCandidates | 4 |
| activeCandidateCount | 1 |
| reviewRequiredCount | 3 |
| rejectCount | 0 |
| averageScore | 85.0 |

### 참고 파일

- `apps/worker/src/test/java/com/tr1l/worker/reliability/ai/GeneratedInvariantParser.java`
- `apps/worker/src/test/java/com/tr1l/worker/reliability/ai/GeneratedInvariantScorer.java`
- `apps/worker/src/test/java/com/tr1l/worker/reliability/ai/OpenAiResponsesInvariantGenerator.java`
- `apps/worker/src/test/java/com/tr1l/worker/reliability/Job1AiInvariantLiveGenerationTest.java`
- `apps/worker/build/job1-ai-invariant-results/sample-generated-invariant-score/generated-candidate-evaluation.json`
- `apps/worker/build/test-results/test/TEST-com.tr1l.worker.reliability.Job1AiInvariantGeneratorContractTest.xml`
- `apps/worker/build/test-results/test/TEST-com.tr1l.worker.reliability.Job1AiInvariantScoringContractTest.xml`
- `apps/worker/build/test-results/test/TEST-com.tr1l.worker.reliability.Job1AiInvariantLiveGenerationTest.xml`

### live 실행 메모

실제 OpenAI 응답 캡처는 아래 조건에서 바로 가능하도록 넣었습니다

- `OPENAI_API_KEY`
- `JOB1_AI_INVARIANT_LIVE_ENABLED=true`
- `JOB1_AI_INVARIANT_OPENAI_MODEL=gpt-5.4-mini`

이후 live 실행 시 아래 파일이 생성됩니다

- `request-body.json`
- `response-body.json`
- `response-output-text.json`
- `generated-candidates.json`
- `generated-candidate-evaluation.json`
- `generation-metrics.json`


<br/>

## 🎫 Jira Ticket
- Jira Ticket: TR1L-157

<br/>

## #️⃣관련 이슈

- closes #343
