### PR TITLE
[TR1L-158] test: Job1 AI invariant review 승격 및 mutation 검증

### DIFF
--- a/apps/worker/src/test/java/com/tr1l/worker/reliability/Job1AiInvariantGeneratorContractTest.java
+++ b/apps/worker/src/test/java/com/tr1l/worker/reliability/Job1AiInvariantGeneratorContractTest.java
@@ -49,13 +49,15 @@ class Job1AiInvariantGeneratorContractTest {
         Job1InvariantPrompt prompt = promptComposer.compose(contextPackBuilder.build());
 
         assertThat(prompt.systemPrompt())
-                .contains("JSON 배열만 출력")
+                .contains("JSON 객체 하나만 출력")
+                .contains("\"invariants\"")
                 .contains("\"sql_check\"")
                 .contains("PROCESSING 상태");
         assertThat(prompt.userPrompt())
                 .contains("=== billing_targets 테이블 DDL ===")
                 .contains("=== Step3 핵심 코드 ===")
-                .contains("응답은 JSON 배열만 반환");
+                .contains("응답은 JSON 객체 하나만 반환")
+                .contains("최상위 필드는 invariants");
     }
 
     @Test
@@ -107,6 +109,30 @@ class Job1AiInvariantGeneratorContractTest {
         assertThat(candidates).hasSize(4);
         assertThat(candidates).extracting(GeneratedInvariantCandidate::id)
                 .containsExactly("INV-101", "INV-102", "INV-103", "INV-104");
+    }
+
+    @Test
+    @DisplayName("배열 형태 legacy 응답도 같은 후보 목록으로 읽는지 보기")
+    void parserShouldAcceptLegacyArrayResponse() {
+        // legacy 배열 응답 호환
+        String legacyArrayResponse = """
+                [
+                  {
+                    "id": "INV-101",
+                    "category": "count_consistency",
+                    "description": "legacy 배열 응답",
+                    "scope": "step_complete",
+                    "sql_check": "SELECT 1",
+                    "violated_by": "legacy path",
+                    "severity": "critical"
+                  }
+                ]
+                """;
+
+        List<GeneratedInvariantCandidate> candidates = parser.parse(legacyArrayResponse);
+
+        assertThat(candidates).hasSize(1);
+        assertThat(candidates.get(0).id()).isEqualTo("INV-101");
     }
 
     @Test

--- a/apps/worker/src/test/java/com/tr1l/worker/reliability/Job1AiInvariantLiveGenerationTest.java
+++ b/apps/worker/src/test/java/com/tr1l/worker/reliability/Job1AiInvariantLiveGenerationTest.java
@@ -10,6 +10,7 @@ import com.tr1l.worker.reliability.ai.Job1InvariantContextPackBuilder;
 import com.tr1l.worker.reliability.ai.Job1InvariantPrompt;
 import com.tr1l.worker.reliability.ai.Job1InvariantPromptComposer;
 import com.tr1l.worker.reliability.ai.OpenAiInvariantGenerationResult;
+import com.tr1l.worker.reliability.ai.OpenAiApiRequestException;
 import com.tr1l.worker.reliability.ai.OpenAiInvariantRuntimeConfig;
 import com.tr1l.worker.reliability.ai.OpenAiResponsesInvariantGenerator;
 import com.tr1l.worker.reliability.support.AllureEvidenceWriter;
@@ -52,8 +53,29 @@ class Job1AiInvariantLiveGenerationTest {
         Job1InvariantPrompt prompt = promptComposer.compose(contextPackBuilder.build());
         OpenAiResponsesInvariantGenerator generator = new OpenAiResponsesInvariantGenerator(config);
 
-        long inputTokenCount = generator.countInputTokens(prompt);
-        OpenAiInvariantGenerationResult generationResult = generator.generate(prompt);
+        long inputTokenCount;
+        OpenAiInvariantGenerationResult generationResult;
+
+        try {
+            inputTokenCount = generator.countInputTokens(prompt);
+            generationResult = generator.generate(prompt);
+        } catch (OpenAiApiRequestException e) {
+            // 실패 요청 캡처 저장
+            artifactWriter.writeText(config.runName(), "failed-request-body.json", e.requestBody());
+            artifactWriter.writeText(config.runName(), "failed-response-body.json", e.responseBody());
+            artifactWriter.writeJson(
+                    config.runName(),
+                    "failed-response-meta.json",
+                    Map.of(
+                            "path", e.path(),
+                            "statusCode", e.statusCode()
+                    )
+            );
+            evidenceWriter.attachText("failed-request-body.json", e.requestBody());
+            evidenceWriter.attachText("failed-response-body.json", e.responseBody());
+            throw e;
+        }
+
         List<GeneratedInvariantCandidate> candidates = parser.parse(generationResult.outputText());
         GeneratedInvariantBatchEvaluation evaluation = scorer.evaluate(candidates, catalog.loadActiveInvariants());
 
@@ -66,7 +88,8 @@ class Job1AiInvariantLiveGenerationTest {
                 config.runName(),
                 "generation-metrics.json",
                 Map.of(
-                        "model", config.model(),
+                        "requestedModel", config.model(),
+                        "responseModel", generationResult.model(),
                         "responseId", generationResult.responseId(),
                         "inputTokenCount", inputTokenCount,
                         "usage", generationResult.usage(),
@@ -84,7 +107,7 @@ class Job1AiInvariantLiveGenerationTest {
         evidenceWriter.attachJson("generated-candidate-evaluation.json", evaluation);
 
         assertThat(generationResult.responseId()).isNotBlank();
-        assertThat(generationResult.model()).isEqualTo(config.model());
+        assertThat(generationResult.model()).startsWith(config.model());
         assertThat(inputTokenCount).isPositive();
         assertThat(candidates).isNotEmpty();
         assertThat(evaluation.totalCandidates()).isEqualTo(candidates.size());

--- a/apps/worker/src/test/java/com/tr1l/worker/reliability/Job1AiInvariantScoringContractTest.java
+++ b/apps/worker/src/test/java/com/tr1l/worker/reliability/Job1AiInvariantScoringContractTest.java
@@ -42,13 +42,14 @@ class Job1AiInvariantScoringContractTest {
                 .collect(Collectors.toMap(GeneratedInvariantEvaluation::invariantId, Function.identity()));
 
         assertThat(evaluation.totalCandidates()).isEqualTo(4);
-        assertThat(evaluation.activeCandidateCount()).isEqualTo(1);
-        assertThat(evaluation.reviewRequiredCount()).isEqualTo(3);
+        assertThat(evaluation.activeCandidateCount()).isZero();
+        assertThat(evaluation.reviewRequiredCount()).isEqualTo(4);
         assertThat(evaluation.rejectCount()).isEqualTo(0);
-        assertThat(evaluation.averageScore()).isGreaterThanOrEqualTo(85d);
+        assertThat(evaluation.averageScore()).isGreaterThanOrEqualTo(80d);
 
-        assertThat(byId.get("INV-101").decision()).isEqualTo(GeneratedInvariantPromotionDecision.ACTIVE_CANDIDATE);
-        assertThat(byId.get("INV-101").novelAgainstActive()).isTrue();
+        assertThat(byId.get("INV-101").decision()).isEqualTo(GeneratedInvariantPromotionDecision.REVIEW_REQUIRED);
+        assertThat(byId.get("INV-101").novelAgainstActive()).isFalse();
+        assertThat(byId.get("INV-101").matchedActiveInvariantId()).isEqualTo("INV-004");
         assertThat(byId.get("INV-102").decision()).isEqualTo(GeneratedInvariantPromotionDecision.REVIEW_REQUIRED);
         assertThat(byId.get("INV-102").matchedActiveInvariantId()).isEqualTo("INV-001");
         assertThat(byId.get("INV-103").matchedActiveInvariantId()).isEqualTo("INV-002");

--- a/apps/worker/src/test/java/com/tr1l/worker/reliability/Job1InvariantHumanReviewContractTest.java
+++ b/apps/worker/src/test/java/com/tr1l/worker/reliability/Job1InvariantHumanReviewContractTest.java
@@ -1,0 +1,40 @@
+package com.tr1l.worker.reliability;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.tr1l.worker.reliability.invariant.InvariantDefinition;
+import com.tr1l.worker.reliability.support.ReliabilityObjectMappers;
+import com.tr1l.worker.reliability.support.ReliabilityResourceCatalog;
+import com.tr1l.worker.reliability.support.ReliabilityResourceLoader;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+// 사람이 검토한 승격 기록 검증
+class Job1InvariantHumanReviewContractTest {
+    private static final String REVIEW_PATH = "reliability/invariants/reviewed/J1S3-I7-review.json";
+
+    private final ReliabilityResourceLoader loader = new ReliabilityResourceLoader();
+    private final ReliabilityResourceCatalog catalog = new ReliabilityResourceCatalog();
+
+    @Test
+    @DisplayName("J1S3-I7 검토 기록이 INV-004 active 파일과 이어지는지 보기")
+    void reviewedInvariantShouldReferencePromotedActiveInvariant() throws Exception {
+        // generated 후보에서 active 승격까지 연결 확인
+        JsonNode review = ReliabilityObjectMappers.json().readTree(loader.loadText(REVIEW_PATH));
+        JsonNode promotionTarget = review.path("promotionTarget");
+        String activeInvariantFile = promotionTarget.path("activeInvariantFile").asText();
+        String checkRef = promotionTarget.path("checkRef").asText();
+
+        InvariantDefinition promoted = loader.loadJson(activeInvariantFile, InvariantDefinition.class);
+
+        assertThat(review.path("generatedInvariantId").asText()).isEqualTo("J1S3-I7");
+        assertThat(review.path("reviewStatus").asText()).isEqualTo("approved");
+        assertThat(review.path("scoreSummary").path("totalScore").asInt()).isGreaterThanOrEqualTo(85);
+        assertThat(promotionTarget.path("activeInvariantId").asText()).isEqualTo("INV-004");
+        assertThat(catalog.resourceExists(activeInvariantFile)).isTrue();
+        assertThat(catalog.resourceExists(checkRef)).isTrue();
+        assertThat(promoted.id()).isEqualTo("INV-004");
+        assertThat(promoted.checkRef()).isEqualTo(checkRef);
+    }
+}

--- a/apps/worker/src/test/java/com/tr1l/worker/reliability/Job1InvariantMutationTest.java
+++ b/apps/worker/src/test/java/com/tr1l/worker/reliability/Job1InvariantMutationTest.java
@@ -1,0 +1,153 @@
+package com.tr1l.worker.reliability;
+
+import com.tr1l.worker.reliability.invariant.InvariantDefinition;
+import com.tr1l.worker.reliability.invariant.InvariantResult;
+import com.tr1l.worker.reliability.invariant.PostgresInvariantChecks;
+import com.tr1l.worker.reliability.support.ReliabilityDataSourceFactory;
+import com.tr1l.worker.reliability.support.ReliabilityObjectMappers;
+import com.tr1l.worker.reliability.support.ReliabilityResourceCatalog;
+import com.tr1l.worker.reliability.support.ReliabilityResourceLoader;
+import com.tr1l.worker.reliability.support.ReliabilityRuntimeConfig;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.LocalDate;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Tag("job1-reliability")
+// INV-004 mutation vertical slice
+class Job1InvariantMutationTest {
+    private static final String ORIGINAL_PATH =
+            "reliability/invariants/active/INV-004-target-work-membership-match.json";
+    private static final String MUTANT_PATH =
+            "reliability/invariants/mutants/MUT-INV-004-loose-count-gap.json";
+    private static final long ORPHAN_USER_ID = 90_000_001L;
+
+    private final ReliabilityResourceLoader loader = new ReliabilityResourceLoader();
+    private final ReliabilityResourceCatalog catalog = new ReliabilityResourceCatalog();
+    private final ReliabilityDataSourceFactory dataSourceFactory = new ReliabilityDataSourceFactory();
+
+    @Test
+    @DisplayName("INV-004 는 단건 불일치를 잡고 느슨한 mutant 는 놓치는지 보기")
+    void originalInvariantShouldCatchSingleMismatchThatLooseMutantMisses() throws Exception {
+        assumeLocalReliabilityEnabled();
+
+        ReliabilityRuntimeConfig config = ReliabilityRuntimeConfig.fromEnvironment();
+        NamedParameterJdbcTemplate jdbcTemplate =
+                new NamedParameterJdbcTemplate(dataSourceFactory.createTargetDataSource(config));
+        PostgresInvariantChecks checks = new PostgresInvariantChecks(jdbcTemplate, catalog);
+
+        InvariantDefinition original = loader.loadJson(ORIGINAL_PATH, InvariantDefinition.class);
+        InvariantDefinition mutant = loader.loadJson(MUTANT_PATH, InvariantDefinition.class);
+        LocalDate billingMonthDay = LocalDate.parse("2026-01-01");
+
+        try {
+            cleanupOrphanWork(jdbcTemplate, billingMonthDay);
+
+            InvariantResult originalBefore = checks.execute(original, billingMonthDay);
+            InvariantResult mutantBefore = checks.execute(mutant, billingMonthDay);
+
+            insertOrphanWork(jdbcTemplate, billingMonthDay);
+
+            InvariantResult originalAfter = checks.execute(original, billingMonthDay);
+            InvariantResult mutantAfter = checks.execute(mutant, billingMonthDay);
+
+            writeMutationReport(originalBefore, mutantBefore, originalAfter, mutantAfter);
+
+            assertThat(originalBefore.passed()).isTrue();
+            assertThat(mutantBefore.passed()).isTrue();
+            assertThat(originalAfter.passed()).isFalse();
+            assertThat(originalAfter.violationCount()).isEqualTo(1);
+            assertThat(mutantAfter.passed()).isTrue();
+            assertThat(mutantAfter.violationCount()).isZero();
+        } finally {
+            cleanupOrphanWork(jdbcTemplate, billingMonthDay);
+        }
+    }
+
+    // 로컬 reliability 실행 조건
+    private void assumeLocalReliabilityEnabled() {
+        Assumptions.assumeTrue(
+                "true".equalsIgnoreCase(System.getenv("JOB1_RELIABILITY_ENABLED")),
+                "Set JOB1_RELIABILITY_ENABLED=true to run local Job1 mutation validation"
+        );
+    }
+
+    // 단건 고아 work 주입
+    private void insertOrphanWork(NamedParameterJdbcTemplate jdbcTemplate, LocalDate billingMonthDay) {
+        jdbcTemplate.update(
+                """
+                        INSERT INTO billing_work (
+                            billing_month_day,
+                            user_id,
+                            status,
+                            attempt_count
+                        )
+                        VALUES (
+                            :billingMonthDay,
+                            :userId,
+                            'TARGET',
+                            0
+                        )
+                        """,
+                new MapSqlParameterSource()
+                        .addValue("billingMonthDay", billingMonthDay)
+                        .addValue("userId", ORPHAN_USER_ID)
+        );
+    }
+
+    // 테스트 데이터 정리
+    private void cleanupOrphanWork(NamedParameterJdbcTemplate jdbcTemplate, LocalDate billingMonthDay) {
+        jdbcTemplate.update(
+                """
+                        DELETE FROM billing_work
+                        WHERE billing_month_day = :billingMonthDay
+                          AND user_id = :userId
+                        """,
+                new MapSqlParameterSource()
+                        .addValue("billingMonthDay", billingMonthDay)
+                        .addValue("userId", ORPHAN_USER_ID)
+        );
+    }
+
+    // mutation 결과 저장
+    private void writeMutationReport(
+            InvariantResult originalBefore,
+            InvariantResult mutantBefore,
+            InvariantResult originalAfter,
+            InvariantResult mutantAfter
+    ) throws Exception {
+        Path output = Paths.get(
+                "build",
+                "job1-reliability-results",
+                "mutation",
+                "INV-004-vs-MUT-INV-004",
+                "mutation-result.json"
+        );
+        Files.createDirectories(output.getParent());
+        Files.writeString(
+                output,
+                ReliabilityObjectMappers.json().writeValueAsString(Map.of(
+                        "mutationTarget", "INV-004",
+                        "mutantId", "MUT-INV-004",
+                        "injectedMismatchCount", 1,
+                        "originalBefore", originalBefore,
+                        "mutantBefore", mutantBefore,
+                        "originalAfter", originalAfter,
+                        "mutantAfter", mutantAfter,
+                        "interpretation", "원본은 단건 불일치를 잡지만 느슨한 mutant 는 5건 이하 불일치를 놓침"
+                )),
+                StandardCharsets.UTF_8
+        );
+    }
+}

--- a/apps/worker/src/test/java/com/tr1l/worker/reliability/Job1ReliabilityResourceContractTest.java
+++ b/apps/worker/src/test/java/com/tr1l/worker/reliability/Job1ReliabilityResourceContractTest.java
@@ -41,9 +41,9 @@ class Job1ReliabilityResourceContractTest {
         // 불변 조건 리소스 연결 검증
         List<InvariantDefinition> invariants = catalog.loadActiveInvariants();
 
-        assertThat(invariants).hasSize(3);
+        assertThat(invariants).hasSize(4);
         assertThat(invariants).extracting(InvariantDefinition::id)
-                .containsExactly("INV-001", "INV-002", "INV-003");
+                .containsExactly("INV-001", "INV-002", "INV-003", "INV-004");
         assertThat(invariants).allSatisfy(definition -> {
             assertThat(catalog.resourceExists(definition.checkRef()))
                     .as("checkRef exists for %s", definition.id())
@@ -62,8 +62,9 @@ class Job1ReliabilityResourceContractTest {
         Job1ScenarioDefinition rerun = catalog.loadScenario("S-001R");
 
         assertThat(normalRun.datasetId()).isEqualTo("D1-rerun-mvp");
-        assertThat(normalRun.validate().invariants()).containsExactly("INV-001", "INV-002", "INV-003");
+        assertThat(normalRun.validate().invariants()).containsExactly("INV-001", "INV-002", "INV-003", "INV-004");
         assertThat(rerun.datasetId()).isEqualTo("D1-rerun-mvp");
+        assertThat(rerun.validate().invariants()).containsExactly("INV-001", "INV-002", "INV-003", "INV-004");
         assertThat(rerun.compareWithBaseline()).isNotNull();
         assertThat(rerun.compareWithBaseline().baselineScenarioId()).isEqualTo("S-001");
         assertThat(rerun.compareWithBaseline().metrics())
@@ -86,6 +87,8 @@ class Job1ReliabilityResourceContractTest {
         assertThat(rerunAfterPartialFailure.datasetId()).isEqualTo("D1-rerun-mvp");
         assertThat(rerunAfterPartialFailure.rerun().enabled()).isTrue();
         assertThat(rerunAfterPartialFailure.validate().phase()).isEqualTo("after_rerun_complete");
+        assertThat(rerunAfterPartialFailure.validate().invariants())
+                .containsExactly("INV-001", "INV-002", "INV-003", "INV-004");
         assertThat(rerunAfterPartialFailure.compareWithBaseline()).isNotNull();
         assertThat(rerunAfterPartialFailure.compareWithBaseline().baselineScenarioId()).isEqualTo("S-001");
         assertThat(rerunAfterPartialFailure.compareWithBaseline().metrics())

--- a/apps/worker/src/test/java/com/tr1l/worker/reliability/ai/GeneratedInvariantParser.java
+++ b/apps/worker/src/test/java/com/tr1l/worker/reliability/ai/GeneratedInvariantParser.java
@@ -2,6 +2,7 @@ package com.tr1l.worker.reliability.ai;
 
 import com.tr1l.worker.reliability.support.ReliabilityObjectMappers;
 import com.tr1l.worker.reliability.support.ReliabilityResourceLoader;
+import com.fasterxml.jackson.databind.JsonNode;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -23,12 +24,25 @@ public final class GeneratedInvariantParser {
     public List<GeneratedInvariantCandidate> parse(String raw) {
         String cleaned = stripCodeFence(raw);
         try {
+            JsonNode root = ReliabilityObjectMappers.json().readTree(cleaned);
+            JsonNode candidateArray = unwrapCandidates(root);
             GeneratedInvariantCandidate[] parsed =
-                    ReliabilityObjectMappers.json().readValue(cleaned, GeneratedInvariantCandidate[].class);
+                    ReliabilityObjectMappers.json().treeToValue(candidateArray, GeneratedInvariantCandidate[].class);
             return Arrays.asList(parsed);
         } catch (IOException e) {
             throw new IllegalStateException("Failed to parse generated invariant response", e);
         }
+    }
+
+    // 배열 또는 wrapper 객체 허용
+    private JsonNode unwrapCandidates(JsonNode root) {
+        if (root.isArray()) {
+            return root;
+        }
+        if (root.isObject() && root.path("invariants").isArray()) {
+            return root.path("invariants");
+        }
+        throw new IllegalStateException("Failed to parse generated invariant response");
     }
 
     // 코드펜스 제거

--- a/apps/worker/src/test/java/com/tr1l/worker/reliability/ai/Job1InvariantPromptComposer.java
+++ b/apps/worker/src/test/java/com/tr1l/worker/reliability/ai/Job1InvariantPromptComposer.java
@@ -15,7 +15,9 @@ public final class Job1InvariantPromptComposer {
 
                 %s
 
-                응답은 JSON 배열만 반환
+                응답은 JSON 객체 하나만 반환
+                최상위 필드는 invariants 하나만 사용
+                invariants 안에 invariant 항목 배열을 담기
                 """.formatted(contextPack.renderForUserPrompt()).trim();
 
         return new Job1InvariantPrompt(systemPrompt, userPrompt);

--- a/apps/worker/src/test/java/com/tr1l/worker/reliability/ai/OpenAiApiRequestException.java
+++ b/apps/worker/src/test/java/com/tr1l/worker/reliability/ai/OpenAiApiRequestException.java
@@ -1,0 +1,33 @@
+package com.tr1l.worker.reliability.ai;
+
+// OpenAI 요청 실패 정보
+public final class OpenAiApiRequestException extends IllegalStateException {
+    private final String path;
+    private final int statusCode;
+    private final String requestBody;
+    private final String responseBody;
+
+    public OpenAiApiRequestException(String path, int statusCode, String requestBody, String responseBody) {
+        super("OpenAI API request failed: path=" + path + " status=" + statusCode + " body=" + responseBody);
+        this.path = path;
+        this.statusCode = statusCode;
+        this.requestBody = requestBody;
+        this.responseBody = responseBody;
+    }
+
+    public String path() {
+        return path;
+    }
+
+    public int statusCode() {
+        return statusCode;
+    }
+
+    public String requestBody() {
+        return requestBody;
+    }
+
+    public String responseBody() {
+        return responseBody;
+    }
+}

--- a/apps/worker/src/test/java/com/tr1l/worker/reliability/ai/OpenAiResponsesInvariantGenerator.java
+++ b/apps/worker/src/test/java/com/tr1l/worker/reliability/ai/OpenAiResponsesInvariantGenerator.java
@@ -22,7 +22,7 @@ public final class OpenAiResponsesInvariantGenerator {
     }
 
     public long countInputTokens(Job1InvariantPrompt prompt) {
-        ObjectNode requestBody = baseRequestBody(prompt);
+        ObjectNode requestBody = buildInputTokenCountRequestBody(prompt);
         String responseBody = send("/responses/input_tokens", requestBody);
 
         try {
@@ -34,9 +34,7 @@ public final class OpenAiResponsesInvariantGenerator {
     }
 
     public OpenAiInvariantGenerationResult generate(Job1InvariantPrompt prompt) {
-        ObjectNode requestBody = baseRequestBody(prompt);
-        requestBody.put("max_output_tokens", 3000);
-        requestBody.set("text", buildStructuredOutputFormat());
+        ObjectNode requestBody = buildGenerationRequestBody(prompt);
 
         String requestBodyText = toPrettyJson(requestBody);
         String responseBody = send("/responses", requestBody);
@@ -60,14 +58,27 @@ public final class OpenAiResponsesInvariantGenerator {
         }
     }
 
-    // 공통 요청 바디
-    private ObjectNode baseRequestBody(Job1InvariantPrompt prompt) {
-        ObjectNode requestBody = ReliabilityObjectMappers.json().createObjectNode();
-        requestBody.put("model", config.model());
-        requestBody.put("store", false);
+    // input token 계산용 요청 바디
+    ObjectNode buildInputTokenCountRequestBody(Job1InvariantPrompt prompt) {
+        return baseConversationRequestBody(prompt);
+    }
+
+    // 응답 생성용 요청 바디
+    ObjectNode buildGenerationRequestBody(Job1InvariantPrompt prompt) {
+        ObjectNode requestBody = baseConversationRequestBody(prompt);
 
         ObjectNode reasoning = requestBody.putObject("reasoning");
         reasoning.put("effort", config.reasoningEffort());
+
+        requestBody.put("max_output_tokens", 3000);
+        requestBody.set("text", buildStructuredOutputFormat());
+        return requestBody;
+    }
+
+    // 공통 대화 바디
+    private ObjectNode baseConversationRequestBody(Job1InvariantPrompt prompt) {
+        ObjectNode requestBody = ReliabilityObjectMappers.json().createObjectNode();
+        requestBody.put("model", config.model());
 
         ArrayNode input = requestBody.putArray("input");
         ObjectNode systemMessage = input.addObject();
@@ -89,9 +100,15 @@ public final class OpenAiResponsesInvariantGenerator {
         format.put("strict", true);
 
         ObjectNode schema = format.putObject("schema");
-        schema.put("type", "array");
+        schema.put("type", "object");
+        ObjectNode schemaProperties = schema.putObject("properties");
+        ObjectNode invariants = schemaProperties.putObject("invariants");
+        invariants.put("type", "array");
+        ArrayNode requiredRoot = schema.putArray("required");
+        requiredRoot.add("invariants");
+        schema.put("additionalProperties", false);
 
-        ObjectNode item = schema.putObject("items");
+        ObjectNode item = invariants.putObject("items");
         item.put("type", "object");
 
         ObjectNode properties = item.putObject("properties");
@@ -136,15 +153,16 @@ public final class OpenAiResponsesInvariantGenerator {
     // 응답 전송
     private String send(String path, JsonNode requestBody) {
         try {
+            String requestBodyText = toPrettyJson(requestBody);
             HttpRequest request = HttpRequest.newBuilder(URI.create(config.baseUrl() + path))
                     .header("Authorization", "Bearer " + config.apiKey())
                     .header("Content-Type", "application/json")
-                    .POST(HttpRequest.BodyPublishers.ofString(toPrettyJson(requestBody), StandardCharsets.UTF_8))
+                    .POST(HttpRequest.BodyPublishers.ofString(requestBodyText, StandardCharsets.UTF_8))
                     .build();
 
             HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
             if (response.statusCode() >= 400) {
-                throw new IllegalStateException("OpenAI API request failed: status=" + response.statusCode() + " body=" + response.body());
+                throw new OpenAiApiRequestException(path, response.statusCode(), requestBodyText, response.body());
             }
             return response.body();
         } catch (InterruptedException e) {

--- a/apps/worker/src/test/java/com/tr1l/worker/reliability/ai/OpenAiResponsesInvariantGeneratorContractTest.java
+++ b/apps/worker/src/test/java/com/tr1l/worker/reliability/ai/OpenAiResponsesInvariantGeneratorContractTest.java
@@ -1,0 +1,53 @@
+package com.tr1l.worker.reliability.ai;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+// OpenAI 요청 바디 계약 검증
+class OpenAiResponsesInvariantGeneratorContractTest {
+    private final Job1InvariantContextPackBuilder contextPackBuilder = new Job1InvariantContextPackBuilder();
+    private final Job1InvariantPromptComposer promptComposer = new Job1InvariantPromptComposer();
+    private final OpenAiResponsesInvariantGenerator generator = new OpenAiResponsesInvariantGenerator(
+            new OpenAiInvariantRuntimeConfig(
+                    "test-key",
+                    "https://api.openai.com/v1",
+                    "gpt-5.4-mini",
+                    "low",
+                    "test-run"
+            )
+    );
+
+    @Test
+    @DisplayName("input token 계산 바디에는 최소 필드만 담는지 보기")
+    void inputTokenCountRequestShouldContainOnlyMinimalFields() {
+        // input token 요청 최소 바디 확인
+        Job1InvariantPrompt prompt = promptComposer.compose(contextPackBuilder.build());
+        var requestBody = generator.buildInputTokenCountRequestBody(prompt);
+
+        assertThat(requestBody.has("store")).isFalse();
+        assertThat(requestBody.has("text")).isFalse();
+        assertThat(requestBody.has("reasoning")).isFalse();
+        assertThat(requestBody.has("max_output_tokens")).isFalse();
+        assertThat(requestBody.path("model").asText()).isEqualTo("gpt-5.4-mini");
+        assertThat(requestBody.path("input").size()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("응답 생성 바디에는 structured output 과 reasoning 을 같이 담는지 보기")
+    void generationRequestShouldContainStructuredOutputFields() {
+        // 응답 생성 요청 바디 확인
+        Job1InvariantPrompt prompt = promptComposer.compose(contextPackBuilder.build());
+        var requestBody = generator.buildGenerationRequestBody(prompt);
+
+        assertThat(requestBody.path("reasoning").path("effort").asText()).isEqualTo("low");
+        assertThat(requestBody.path("max_output_tokens").asInt()).isEqualTo(3000);
+        assertThat(requestBody.path("text").path("format").path("type").asText())
+                .isEqualTo("json_schema");
+        assertThat(requestBody.path("text").path("format").path("schema").path("type").asText())
+                .isEqualTo("object");
+        assertThat(requestBody.path("text").path("format").path("schema").path("properties").path("invariants").path("type").asText())
+                .isEqualTo("array");
+    }
+}

--- a/apps/worker/src/test/resources/reliability/ai/prompts/job1-invariant-generator-system.txt
+++ b/apps/worker/src/test/resources/reliability/ai/prompts/job1-invariant-generator-system.txt
@@ -3,7 +3,9 @@
 주어진 스키마 코드 상태 전이 규칙을 읽고 Job1 Step3 가 올바르게 동작할 때 반드시 성립해야 하는 invariant 후보를 도출하라
 
 출력 규칙
-1. JSON 배열만 출력
+1. JSON 객체 하나만 출력
+   - 최상위 키는 "invariants" 하나만 사용
+   - "invariants" 값은 invariant 배열
 2. 각 항목은 아래 필드를 모두 포함
    - "id"
    - "category"

--- a/apps/worker/src/test/resources/reliability/checks/postgres/INV-004.sql
+++ b/apps/worker/src/test/resources/reliability/checks/postgres/INV-004.sql
@@ -1,0 +1,15 @@
+-- target 과 work 사용자 집합 차이 확인
+-- 누락 또는 고아 work 모두 재실행 안전성 위협
+SELECT COALESCE(bt.user_id, bw.user_id) AS user_id,
+       bt.billing_month AS target_billing_month,
+       bw.billing_month_day AS work_billing_month_day,
+       CASE
+           WHEN bt.user_id IS NULL THEN 'WORK_WITHOUT_TARGET'
+           WHEN bw.user_id IS NULL THEN 'TARGET_WITHOUT_WORK'
+       END AS mismatch_type
+FROM billing_targets bt
+FULL OUTER JOIN billing_work bw
+    ON bw.billing_month_day = bt.billing_month
+   AND bw.user_id = bt.user_id
+WHERE COALESCE(bt.billing_month, bw.billing_month_day) = :billingMonthDay
+  AND (bt.user_id IS NULL OR bw.user_id IS NULL);

--- a/apps/worker/src/test/resources/reliability/checks/postgres/MUT-INV-004.sql
+++ b/apps/worker/src/test/resources/reliability/checks/postgres/MUT-INV-004.sql
@@ -1,0 +1,14 @@
+-- INV-004 를 일부러 느슨하게 만든 mutant
+-- 불일치가 5개 이하면 놓치는 조건
+WITH mismatch AS (
+    SELECT COALESCE(bt.user_id, bw.user_id) AS user_id
+    FROM billing_targets bt
+    FULL OUTER JOIN billing_work bw
+        ON bw.billing_month_day = bt.billing_month
+       AND bw.user_id = bt.user_id
+    WHERE COALESCE(bt.billing_month, bw.billing_month_day) = :billingMonthDay
+      AND (bt.user_id IS NULL OR bw.user_id IS NULL)
+)
+SELECT COUNT(*) AS mismatch_count
+FROM mismatch
+HAVING COUNT(*) > 5;

--- a/apps/worker/src/test/resources/reliability/invariants/active/INV-004-target-work-membership-match.json
+++ b/apps/worker/src/test/resources/reliability/invariants/active/INV-004-target-work-membership-match.json
@@ -1,0 +1,13 @@
+{
+  "id": "INV-004",
+  "title": "Target and work membership match",
+  "category": "count_consistency",
+  "scope": "always",
+  "description": "같은 billing_month_day 기준으로 billing_targets 와 billing_work 의 사용자 집합은 같아야 한다",
+  "checkType": "postgres",
+  "checkRef": "reliability/checks/postgres/INV-004.sql",
+  "expectedViolationCount": 0,
+  "severity": "critical",
+  "allureFeature": "Rerun Safety",
+  "allureStory": "Target work membership parity"
+}

--- a/apps/worker/src/test/resources/reliability/invariants/generated/job1-invariant-candidates.sample.json
+++ b/apps/worker/src/test/resources/reliability/invariants/generated/job1-invariant-candidates.sample.json
@@ -1,38 +1,40 @@
-[
-  {
-    "id": "INV-101",
-    "category": "count_consistency",
-    "description": "특정 billing_month_day 의 CALCULATED billing_work 수는 billing_targets 수를 넘으면 안 된다",
-    "scope": "step_complete",
-    "sql_check": "SELECT bw.billing_month_day FROM billing_work bw LEFT JOIN billing_targets bt ON bt.billing_month = bw.billing_month_day AND bt.user_id = bw.user_id WHERE bw.billing_month_day = :month GROUP BY bw.billing_month_day HAVING COUNT(*) FILTER (WHERE bw.status = 'CALCULATED') > COUNT(bt.user_id)",
-    "violated_by": "중복 work 생성 뒤 둘 다 CALCULATED 로 끝난 경우",
-    "severity": "critical"
-  },
-  {
-    "id": "INV-102",
-    "category": "state_consistency",
-    "description": "같은 billing_month_day 와 user_id 조합의 billing_work 는 최대 1개여야 한다",
-    "scope": "always",
-    "sql_check": "SELECT billing_month_day, user_id FROM billing_work WHERE billing_month_day = :month GROUP BY billing_month_day, user_id HAVING COUNT(*) > 1",
-    "violated_by": "work insert 경로가 멱등하지 않게 바뀐 경우",
-    "severity": "critical"
-  },
-  {
-    "id": "INV-103",
-    "category": "temporal",
-    "description": "재실행이 끝난 뒤에는 lease_until 이 지난 PROCESSING work 가 남아 있으면 안 된다",
-    "scope": "rerun_after_crash",
-    "sql_check": "SELECT user_id FROM billing_work WHERE billing_month_day = :month AND status = 'PROCESSING' AND lease_until < NOW()",
-    "violated_by": "재실행이 끝났는데 reclaim 되지 않은 PROCESSING 이 남은 경우",
-    "severity": "major"
-  },
-  {
-    "id": "INV-104",
-    "category": "referential",
-    "description": "CALCULATED 상태의 billing_work 는 MongoDB billing_snapshot 에 대응 workId 가 있어야 한다",
-    "scope": "rerun_after_crash",
-    "sql_check": "cross-db: SELECT work_id FROM billing_work WHERE billing_month_day = :month AND status = 'CALCULATED' THEN compare with MongoDB billing_snapshot.workId",
-    "violated_by": "Mongo 저장 전에 끊기거나 rerun 수렴이 누락된 경우",
-    "severity": "critical"
-  }
-]
+{
+  "invariants": [
+    {
+      "id": "INV-101",
+      "category": "count_consistency",
+      "description": "특정 billing_month_day 의 CALCULATED billing_work 수는 billing_targets 수를 넘으면 안 된다",
+      "scope": "step_complete",
+      "sql_check": "SELECT bw.billing_month_day FROM billing_work bw LEFT JOIN billing_targets bt ON bt.billing_month = bw.billing_month_day AND bt.user_id = bw.user_id WHERE bw.billing_month_day = :month GROUP BY bw.billing_month_day HAVING COUNT(*) FILTER (WHERE bw.status = 'CALCULATED') > COUNT(bt.user_id)",
+      "violated_by": "중복 work 생성 뒤 둘 다 CALCULATED 로 끝난 경우",
+      "severity": "critical"
+    },
+    {
+      "id": "INV-102",
+      "category": "state_consistency",
+      "description": "같은 billing_month_day 와 user_id 조합의 billing_work 는 최대 1개여야 한다",
+      "scope": "always",
+      "sql_check": "SELECT billing_month_day, user_id FROM billing_work WHERE billing_month_day = :month GROUP BY billing_month_day, user_id HAVING COUNT(*) > 1",
+      "violated_by": "work insert 경로가 멱등하지 않게 바뀐 경우",
+      "severity": "critical"
+    },
+    {
+      "id": "INV-103",
+      "category": "temporal",
+      "description": "재실행이 끝난 뒤에는 lease_until 이 지난 PROCESSING work 가 남아 있으면 안 된다",
+      "scope": "rerun_after_crash",
+      "sql_check": "SELECT user_id FROM billing_work WHERE billing_month_day = :month AND status = 'PROCESSING' AND lease_until < NOW()",
+      "violated_by": "재실행이 끝났는데 reclaim 되지 않은 PROCESSING 이 남은 경우",
+      "severity": "major"
+    },
+    {
+      "id": "INV-104",
+      "category": "referential",
+      "description": "CALCULATED 상태의 billing_work 는 MongoDB billing_snapshot 에 대응 workId 가 있어야 한다",
+      "scope": "rerun_after_crash",
+      "sql_check": "cross-db: SELECT work_id FROM billing_work WHERE billing_month_day = :month AND status = 'CALCULATED' THEN compare with MongoDB billing_snapshot.workId",
+      "violated_by": "Mongo 저장 전에 끊기거나 rerun 수렴이 누락된 경우",
+      "severity": "critical"
+    }
+  ]
+}

--- a/apps/worker/src/test/resources/reliability/invariants/mutants/MUT-INV-004-loose-count-gap.json
+++ b/apps/worker/src/test/resources/reliability/invariants/mutants/MUT-INV-004-loose-count-gap.json
@@ -1,0 +1,13 @@
+{
+  "id": "MUT-INV-004",
+  "title": "Loose target work gap",
+  "category": "count_consistency",
+  "scope": "always",
+  "description": "같은 billing_month_day 기준으로 target 과 work 차이가 5개 이하면 허용한다",
+  "checkType": "postgres",
+  "checkRef": "reliability/checks/postgres/MUT-INV-004.sql",
+  "expectedViolationCount": 0,
+  "severity": "major",
+  "allureFeature": "Invariant Mutation",
+  "allureStory": "Loose target work gap mutant"
+}

--- a/apps/worker/src/test/resources/reliability/invariants/reviewed/J1S3-I7-review.json
+++ b/apps/worker/src/test/resources/reliability/invariants/reviewed/J1S3-I7-review.json
@@ -1,0 +1,31 @@
+{
+  "generatedInvariantId": "J1S3-I7",
+  "sourceRunName": "live-job1-invariant-generator",
+  "sourceResponseId": "resp_0935f9ac0da1a53e0069e918dbe4f0819a9d28b987a349085f",
+  "reviewStatus": "approved",
+  "reviewedBy": "kimdoyeon",
+  "reviewedAt": "2026-04-23T03:30:00Z",
+  "scoreSummary": {
+    "totalScore": 85,
+    "formatScore": 20,
+    "sqlExecutableScore": 25,
+    "semanticAlignmentScore": 25,
+    "scenarioLinkageScore": 0,
+    "noveltyScore": 15,
+    "sqlExecutable": true,
+    "semanticallyAligned": true,
+    "scenarioLinked": false,
+    "novelAgainstActive": true
+  },
+  "decisionReason": "billing_targets 와 billing_work 의 사용자 집합 일치 여부는 재실행 안전성에서 별도 경계로 볼 가치가 있음",
+  "reviewNotes": [
+    "LLM 생성 결과는 count_consistency 로 분류됐지만 단순 count 보다 사용자 집합 차이를 보는 쪽이 더 안전함",
+    "scenarioLinked 점수는 낮았지만 S-001 S-001R S-003R 검증 목록에 직접 연결해서 보완함",
+    "cross-db 가 아닌 Postgres 내부 membership 검증으로 먼저 승격함"
+  ],
+  "promotionTarget": {
+    "activeInvariantId": "INV-004",
+    "activeInvariantFile": "reliability/invariants/active/INV-004-target-work-membership-match.json",
+    "checkRef": "reliability/checks/postgres/INV-004.sql"
+  }
+}

--- a/apps/worker/src/test/resources/reliability/scenarios/S-001-normal-run.yml
+++ b/apps/worker/src/test/resources/reliability/scenarios/S-001-normal-run.yml
@@ -21,6 +21,7 @@ validate:
     - INV-001
     - INV-002
     - INV-003
+    - INV-004
 
 allure:
   epic: "TR1L Job1 Reliability"

--- a/apps/worker/src/test/resources/reliability/scenarios/S-001R-same-cutoff-rerun.yml
+++ b/apps/worker/src/test/resources/reliability/scenarios/S-001R-same-cutoff-rerun.yml
@@ -22,6 +22,7 @@ validate:
     - INV-001
     - INV-002
     - INV-003
+    - INV-004
 
 compareWithBaseline:
   enabled: true

--- a/apps/worker/src/test/resources/reliability/scenarios/S-003R-rerun-after-partial-success.yml
+++ b/apps/worker/src/test/resources/reliability/scenarios/S-003R-rerun-after-partial-success.yml
@@ -22,6 +22,7 @@ validate:
     - INV-001
     - INV-002
     - INV-003
+    - INV-004
 
 compareWithBaseline:
   enabled: true


### PR DESCRIPTION
## 📝작업 내용

이번 PR에서는 Job1 AI invariant generator 결과를 바로 active 로 쓰지 않고 사람이 검토한 뒤 승격하는 흐름을 추가했습니다

`gpt-5.4-mini` live 응답에서 나온 후보 중 `J1S3-I7` 을 검토 기록으로 남기고 `INV-004` 로 승격했습니다
그리고 같은 조건을 일부러 느슨하게 만든 `MUT-INV-004` 를 추가해서 원본 invariant 와 mutant 의 차이가 테스트 코드로 보이게 했습니다

이 PR은 `TR1L-157` 위에 쌓는 stacked PR 입니다

<br/>

## 👀변경 사항

| 구분 | 변경 내용 | 이유 |
| --- | --- | --- |
| OpenAI live | `input_tokens` 요청 바디와 `/responses` 요청 바디 분리 | API별 허용 필드 차이로 인한 실패 방지 |
| OpenAI live | structured output 최상위를 `object` 로 변경 | Responses API 스키마 제약 반영 |
| parser | 배열 응답과 `{ "invariants": [...] }` wrapper 응답 모두 허용 | 샘플과 live 응답 형태를 같이 처리하기 위해 |
| review | `J1S3-I7-review.json` 추가 | LLM 후보를 사람이 승인한 흔적을 남기기 위해 |
| active | `INV-004` 추가 | `billing_targets` 와 `billing_work` 사용자 집합 일치 여부 검증 |
| scenario | `S-001`, `S-001R`, `S-003R` 에 `INV-004` 연결 | 정상 run 재실행 partial success 이후 모두 같은 경계를 보게 하기 위해 |
| mutation | `MUT-INV-004` 추가 | 단건 불일치를 놓치는 느슨한 invariant 를 비교하기 위해 |
| test | human review 계약 테스트와 mutation vertical slice 테스트 추가 | review 승격과 mutant 비교 흐름을 JUnit 으로 고정하기 위해 |

```mermaid
flowchart LR
    A["gpt-5.4-mini live 후보"] --> B["점수화 결과"]
    B --> C["사람 검토 기록"]
    C --> D["INV-004 active 승격"]
    D --> E["S-001 S-001R S-003R 검증 연결"]
    D --> F["MUT-INV-004 생성"]
    F --> G["원본과 mutant 비교 테스트"]

    classDef ai fill:#E8F2FF,stroke:#3B82F6,color:#0F172A
    classDef review fill:#ECFDF5,stroke:#10B981,color:#052E16
    classDef mutation fill:#FFF7ED,stroke:#F97316,color:#431407

    class A,B ai
    class C,D,E review
    class F,G mutation
```

### 테스트 개요

| 항목 | 내용 |
| --- | --- |
| 검증 대상 | Job1 AI invariant review 승격과 mutation vertical slice |
| D1 입력 수치 | users `30,000`, target eligible `28,500` |
| live 모델 | `gpt-5.4-mini` |
| live 응답 모델 | `gpt-5.4-mini-2026-03-17` |
| live 후보 수 | `7` |
| live 점수화 결과 | active `3`, review `3`, reject `1` |
| live 평균 점수 | `77.85714285714286` |
| live token 사용량 | input `1,842`, output `1,182`, total `3,024` |
| 승격 대상 | `J1S3-I7` -> `INV-004` |
| mutant 대상 | `INV-004` -> `MUT-INV-004` |
| mutation 의도 | mismatch `1` 건은 원본이 잡고 mutant 는 허용 |

### 테스트 결과

| 테스트 | 결과 | 수치 |
| --- | --- | --- |
| `Job1AiInvariantGeneratorContractTest` | PASS | 7 / 7 |
| `Job1ReliabilityResourceContractTest` | PASS | 4 / 4 |
| `Job1InvariantHumanReviewContractTest` | PASS | 1 / 1 |
| `Job1AiInvariantScoringContractTest` | PASS | 1 / 1 |
| `OpenAiResponsesInvariantGeneratorContractTest` | PASS | 2 / 2 |
| `Job1InvariantMutationTest` | SKIP | 1 / 1 `JOB1_RELIABILITY_ENABLED` 미설정 |
| 전체 | PASS | 실행 15 / 15, skip 1 |

### 참고 artifact

| 구분 | 경로 |
| --- | --- |
| live raw response | `apps/worker/build/job1-ai-invariant-results/live-job1-invariant-generator/response-body.json` |
| live output text | `apps/worker/build/job1-ai-invariant-results/live-job1-invariant-generator/response-output-text.json` |
| live 후보 평가 | `apps/worker/build/job1-ai-invariant-results/live-job1-invariant-generator/generated-candidate-evaluation.json` |
| live 정량 지표 | `apps/worker/build/job1-ai-invariant-results/live-job1-invariant-generator/generation-metrics.json` |
| sample 후보 평가 | `apps/worker/build/job1-ai-invariant-results/sample-generated-invariant-score/generated-candidate-evaluation.json` |
| JUnit 결과 | `apps/worker/build/test-results/test/` |

실제 DB mutation 검증은 아래 조건에서 실행됩니다

```bash
JOB1_RELIABILITY_ENABLED=true \
./gradlew :apps:worker:test \
  --tests com.tr1l.worker.reliability.Job1InvariantMutationTest \
  --rerun-tasks
```

<br/>

## 🎫 Jira Ticket
- Jira Ticket: TR1L-158

<br/>

## #️⃣관련 이슈

- closes #346
