### PR TITLE
[TR1L-159] feat: Job1 AI invariant review gate 및 consistency checker 추가

### DIFF
--- a/apps/worker/src/test/java/com/tr1l/worker/reliability/Job1InvariantConsistencyCheckerContractTest.java
+++ b/apps/worker/src/test/java/com/tr1l/worker/reliability/Job1InvariantConsistencyCheckerContractTest.java
@@ -1,0 +1,89 @@
+package com.tr1l.worker.reliability;
+
+import com.tr1l.worker.reliability.ai.AiArtifactWriter;
+import com.tr1l.worker.reliability.ai.GeneratedInvariantCandidate;
+import com.tr1l.worker.reliability.ai.GeneratedInvariantConsistencyChecker;
+import com.tr1l.worker.reliability.ai.GeneratedInvariantParser;
+import com.tr1l.worker.reliability.ai.InvariantConsistencyDecision;
+import com.tr1l.worker.reliability.ai.InvariantConsistencyReport;
+import com.tr1l.worker.reliability.support.ReliabilityResourceCatalog;
+import com.tr1l.worker.reliability.support.ReliabilityResourceLoader;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+// consistency checker 계약 검증
+class Job1InvariantConsistencyCheckerContractTest {
+    private static final String SAMPLE_RESPONSE_PATH =
+            "reliability/invariants/generated/job1-invariant-candidates.sample.json";
+    private static final String CHECKER_PROMPT_PATH =
+            "reliability/ai/prompts/job1-invariant-consistency-checker-system.txt";
+    private static final String CHECKER_RUN_NAME = "consistency-checker";
+
+    private final ReliabilityResourceCatalog catalog = new ReliabilityResourceCatalog();
+    private final ReliabilityResourceLoader loader = new ReliabilityResourceLoader();
+    private final GeneratedInvariantParser parser = new GeneratedInvariantParser();
+    private final GeneratedInvariantConsistencyChecker checker = new GeneratedInvariantConsistencyChecker();
+    private final AiArtifactWriter artifactWriter = new AiArtifactWriter();
+
+    @Test
+    @DisplayName("consistency checker 프롬프트가 별도 검토자 역할과 출력 규칙을 담는지 보기")
+    void consistencyCheckerPromptShouldContainReviewerRules() {
+        // LLM checker 지시문 계약 확인
+        String prompt = loader.loadText(CHECKER_PROMPT_PATH);
+
+        assertThat(prompt)
+                .contains("다른 LLM 이 생성한 invariant 후보")
+                .contains("PASS WARN FAIL")
+                .contains("PROCESSING 상태")
+                .contains("cross-db 검증");
+    }
+
+    @Test
+    @DisplayName("generated 후보를 PASS WARN FAIL consistency 리포트로 나누는지 보기")
+    void generatedCandidatesShouldBeCheckedWithConsistencyReport() {
+        // generated 후보 별도 검토 결과 저장
+        List<GeneratedInvariantCandidate> candidates = parser.loadFromResource(SAMPLE_RESPONSE_PATH);
+        InvariantConsistencyReport report = checker.check(candidates, catalog.loadActiveInvariants());
+
+        artifactWriter.writeJson(CHECKER_RUN_NAME, "job1-invariant-consistency-report.json", report);
+
+        assertThat(report.totalCandidates()).isEqualTo(4);
+        assertThat(report.passCount()).isZero();
+        assertThat(report.warnCount()).isEqualTo(4);
+        assertThat(report.failCount()).isZero();
+        assertThat(report.reviews()).allSatisfy(review ->
+                assertThat(review.decision()).isEqualTo(InvariantConsistencyDecision.WARN)
+        );
+        assertThat(report.reviews().get(0).findings())
+                .anySatisfy(finding -> assertThat(finding.code()).isEqualTo("ACTIVE_DUPLICATE_REVIEW"));
+    }
+
+    @Test
+    @DisplayName("SQL 의미가 맞지 않는 후보는 consistency checker 에서 FAIL 로 막는지 보기")
+    void invalidSqlMeaningShouldFailConsistencyCheck() {
+        // 실패 후보 차단 확인
+        GeneratedInvariantCandidate invalid = new GeneratedInvariantCandidate(
+                "BAD-001",
+                "count_consistency",
+                "billing_work 수가 target 수와 같아야 한다",
+                "always",
+                "SELECT 1",
+                "잘못된 SQL 생성",
+                "critical"
+        );
+
+        InvariantConsistencyReport report = checker.check(List.of(invalid), catalog.loadActiveInvariants());
+
+        assertThat(report.totalCandidates()).isEqualTo(1);
+        assertThat(report.passCount()).isZero();
+        assertThat(report.warnCount()).isZero();
+        assertThat(report.failCount()).isEqualTo(1);
+        assertThat(report.reviews().get(0).findings())
+                .extracting("code")
+                .contains("SQL_SHAPE_INVALID", "CATEGORY_SQL_MISMATCH");
+    }
+}

--- a/apps/worker/src/test/java/com/tr1l/worker/reliability/Job1InvariantReviewGateContractTest.java
+++ b/apps/worker/src/test/java/com/tr1l/worker/reliability/Job1InvariantReviewGateContractTest.java
@@ -1,0 +1,71 @@
+package com.tr1l.worker.reliability;
+
+import com.tr1l.worker.reliability.ai.AiArtifactWriter;
+import com.tr1l.worker.reliability.ai.GeneratedInvariantReviewGate;
+import com.tr1l.worker.reliability.ai.HumanReviewRecord;
+import com.tr1l.worker.reliability.ai.ReviewGateResult;
+import com.tr1l.worker.reliability.invariant.InvariantDefinition;
+import com.tr1l.worker.reliability.support.ReliabilityResourceCatalog;
+import com.tr1l.worker.reliability.support.ReliabilityResourceLoader;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+// human review gate 계약 검증
+class Job1InvariantReviewGateContractTest {
+    private static final String REVIEW_PATH = "reliability/invariants/reviewed/J1S3-I7-review.json";
+    private static final String GATE_RUN_NAME = "review-gate";
+
+    private final ReliabilityResourceLoader loader = new ReliabilityResourceLoader();
+    private final ReliabilityResourceCatalog catalog = new ReliabilityResourceCatalog();
+    private final GeneratedInvariantReviewGate reviewGate = new GeneratedInvariantReviewGate();
+    private final AiArtifactWriter artifactWriter = new AiArtifactWriter();
+
+    @Test
+    @DisplayName("approved review 만 INV-004 active 승격 gate 를 통과하는지 보기")
+    void approvedHumanReviewShouldPassPromotionGate() {
+        // 실제 review 파일 gate 판정
+        HumanReviewRecord review = loader.loadJson(REVIEW_PATH, HumanReviewRecord.class);
+        InvariantDefinition promoted = loader.loadJson(
+                review.promotionTarget().activeInvariantFile(),
+                InvariantDefinition.class
+        );
+
+        ReviewGateResult result = reviewGate.evaluate(review, promoted, catalog);
+        artifactWriter.writeJson(GATE_RUN_NAME, "J1S3-I7-review-gate-result.json", result);
+
+        assertThat(result.passed()).isTrue();
+        assertThat(result.blockers()).isEmpty();
+        assertThat(result.warnings()).containsExactly("scenarioLinked false 를 사람 검토 메모로 보완");
+        assertThat(result.activeInvariantId()).isEqualTo("INV-004");
+    }
+
+    @Test
+    @DisplayName("approved 가 아닌 review 는 active 승격 gate 에서 막히는지 보기")
+    void nonApprovedHumanReviewShouldBeBlocked() {
+        // 상태값 gate 차단 확인
+        HumanReviewRecord review = loader.loadJson(REVIEW_PATH, HumanReviewRecord.class);
+        HumanReviewRecord rejectedReview = new HumanReviewRecord(
+                review.generatedInvariantId(),
+                review.sourceRunName(),
+                review.sourceResponseId(),
+                "needs_revision",
+                review.reviewedBy(),
+                review.reviewedAt(),
+                review.scoreSummary(),
+                review.decisionReason(),
+                review.reviewNotes(),
+                review.promotionTarget()
+        );
+        InvariantDefinition promoted = loader.loadJson(
+                review.promotionTarget().activeInvariantFile(),
+                InvariantDefinition.class
+        );
+
+        ReviewGateResult result = reviewGate.evaluate(rejectedReview, promoted, catalog);
+
+        assertThat(result.passed()).isFalse();
+        assertThat(result.blockers()).contains("reviewStatus 가 approved 가 아님");
+    }
+}

--- a/apps/worker/src/test/java/com/tr1l/worker/reliability/ai/GeneratedInvariantConsistencyChecker.java
+++ b/apps/worker/src/test/java/com/tr1l/worker/reliability/ai/GeneratedInvariantConsistencyChecker.java
@@ -1,0 +1,204 @@
+package com.tr1l.worker.reliability.ai;
+
+import com.tr1l.worker.reliability.invariant.InvariantDefinition;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+// generated invariant 별도 검토자
+public final class GeneratedInvariantConsistencyChecker {
+    private static final Pattern TOKEN_SPLIT = Pattern.compile("[^\\p{L}\\p{Nd}]+");
+    private static final double DUPLICATE_THRESHOLD = 0.25d;
+
+    public InvariantConsistencyReport check(
+            List<GeneratedInvariantCandidate> candidates,
+            List<InvariantDefinition> activeInvariants
+    ) {
+        List<InvariantConsistencyReview> reviews = candidates.stream()
+                .map(candidate -> checkOne(candidate, activeInvariants))
+                .toList();
+
+        int passCount = countByDecision(reviews, InvariantConsistencyDecision.PASS);
+        int warnCount = countByDecision(reviews, InvariantConsistencyDecision.WARN);
+        int failCount = countByDecision(reviews, InvariantConsistencyDecision.FAIL);
+
+        return new InvariantConsistencyReport(
+                reviews,
+                reviews.size(),
+                passCount,
+                warnCount,
+                failCount
+        );
+    }
+
+    // 단건 검토
+    private InvariantConsistencyReview checkOne(
+            GeneratedInvariantCandidate candidate,
+            List<InvariantDefinition> activeInvariants
+    ) {
+        List<InvariantConsistencyFinding> findings = new ArrayList<>();
+
+        checkSqlShape(candidate, findings);
+        checkCategoryMeaning(candidate, findings);
+        checkTemporalScope(candidate, findings);
+        checkDuplicateActive(candidate, activeInvariants, findings);
+
+        InvariantConsistencyDecision decision = decide(findings);
+
+        return new InvariantConsistencyReview(
+                candidate.id(),
+                decision,
+                findings,
+                suggestedAction(decision)
+        );
+    }
+
+    // SQL 형태 검토
+    private void checkSqlShape(GeneratedInvariantCandidate candidate, List<InvariantConsistencyFinding> findings) {
+        String sql = candidate.sqlCheck().trim();
+        String normalized = sql.toUpperCase(Locale.ROOT);
+
+        if (candidate.crossDb()) {
+            findings.add(new InvariantConsistencyFinding(
+                    "CROSS_DB_REVIEW_REQUIRED",
+                    "WARN",
+                    "sql_check",
+                    "cross-db 검증은 SQL 단독 실행보다 별도 executor 검토 필요"
+            ));
+            return;
+        }
+
+        if (!normalized.startsWith("SELECT") || !normalized.contains("FROM") || normalized.contains("...")) {
+            findings.add(new InvariantConsistencyFinding(
+                    "SQL_SHAPE_INVALID",
+                    "FAIL",
+                    "sql_check",
+                    "PostgreSQL 단독 실행 가능한 SELECT 형태가 아님"
+            ));
+        }
+    }
+
+    // category 와 SQL 의미 검토
+    private void checkCategoryMeaning(GeneratedInvariantCandidate candidate, List<InvariantConsistencyFinding> findings) {
+        String sql = candidate.sqlCheck().toUpperCase(Locale.ROOT);
+        String description = normalizeText(candidate.description());
+
+        boolean aligned = switch (candidate.category()) {
+            case "count_consistency" -> sql.contains("COUNT(") || description.contains("집합");
+            case "state_consistency" -> sql.contains("STATUS") || sql.contains("GROUP BY") || description.contains("상태");
+            case "temporal" -> sql.contains("LEASE_UNTIL") || sql.contains("NOW()") || description.contains("재실행");
+            case "referential" -> candidate.crossDb()
+                    || sql.contains("WORK_ID")
+                    || sql.contains("WORKID")
+                    || description.contains("snapshot");
+            default -> false;
+        };
+
+        if (!aligned) {
+            findings.add(new InvariantConsistencyFinding(
+                    "CATEGORY_SQL_MISMATCH",
+                    "FAIL",
+                    "category",
+                    "category 와 sql_check 또는 description 의 의미가 어긋남"
+            ));
+        }
+    }
+
+    // temporal scope 검토
+    private void checkTemporalScope(GeneratedInvariantCandidate candidate, List<InvariantConsistencyFinding> findings) {
+        if (!"temporal".equals(candidate.category())) {
+            return;
+        }
+
+        String description = normalizeText(candidate.description());
+        if ("always".equals(candidate.scope()) && description.contains("재실행")) {
+            findings.add(new InvariantConsistencyFinding(
+                    "TEMPORAL_SCOPE_REVIEW",
+                    "WARN",
+                    "scope",
+                    "재실행 완료 뒤 조건일 수 있어 always 범위 재검토 필요"
+            ));
+        }
+    }
+
+    // active 중복 검토
+    private void checkDuplicateActive(
+            GeneratedInvariantCandidate candidate,
+            List<InvariantDefinition> activeInvariants,
+            List<InvariantConsistencyFinding> findings
+    ) {
+        Set<String> candidateTokens = tokenize(candidate.description());
+
+        activeInvariants.stream()
+                .filter(active -> candidate.category().equals(active.category()))
+                .map(active -> new ActiveSimilarity(active.id(), jaccard(candidateTokens, tokenize(active.description()))))
+                .max(Comparator.comparingDouble(ActiveSimilarity::similarity))
+                .filter(match -> match.similarity() >= DUPLICATE_THRESHOLD)
+                .ifPresent(match -> findings.add(new InvariantConsistencyFinding(
+                        "ACTIVE_DUPLICATE_REVIEW",
+                        "WARN",
+                        "description",
+                        "기존 active invariant " + match.activeInvariantId() + " 와 의미 중복 가능성 존재"
+                )));
+    }
+
+    // 판정 계산
+    private InvariantConsistencyDecision decide(List<InvariantConsistencyFinding> findings) {
+        boolean hasFail = findings.stream().anyMatch(finding -> "FAIL".equals(finding.severity()));
+        if (hasFail) {
+            return InvariantConsistencyDecision.FAIL;
+        }
+
+        boolean hasWarn = findings.stream().anyMatch(finding -> "WARN".equals(finding.severity()));
+        return hasWarn ? InvariantConsistencyDecision.WARN : InvariantConsistencyDecision.PASS;
+    }
+
+    // 후속 조치 문구
+    private String suggestedAction(InvariantConsistencyDecision decision) {
+        return switch (decision) {
+            case PASS -> "active 승격 후보로 검토 가능";
+            case WARN -> "사람 검토 뒤 승격 여부 판단 필요";
+            case FAIL -> "프롬프트 또는 SQL 수정 뒤 재생성 필요";
+        };
+    }
+
+    private int countByDecision(List<InvariantConsistencyReview> reviews, InvariantConsistencyDecision decision) {
+        return (int) reviews.stream()
+                .filter(review -> review.decision() == decision)
+                .count();
+    }
+
+    // 공백 정리
+    private String normalizeText(String text) {
+        return text == null ? "" : text.toLowerCase(Locale.ROOT).replaceAll("\\s+", " ").trim();
+    }
+
+    // 토큰 분리
+    private Set<String> tokenize(String text) {
+        return TOKEN_SPLIT.splitAsStream(normalizeText(text))
+                .filter(token -> !token.isBlank())
+                .collect(Collectors.toSet());
+    }
+
+    // 유사도 계산
+    private double jaccard(Set<String> left, Set<String> right) {
+        if (left.isEmpty() || right.isEmpty()) {
+            return 0d;
+        }
+
+        long intersection = left.stream().filter(right::contains).count();
+        long union = left.size() + right.size() - intersection;
+        return union == 0 ? 0d : (double) intersection / union;
+    }
+
+    private record ActiveSimilarity(
+            String activeInvariantId,
+            double similarity
+    ) {
+    }
+}

--- a/apps/worker/src/test/java/com/tr1l/worker/reliability/ai/GeneratedInvariantReviewGate.java
+++ b/apps/worker/src/test/java/com/tr1l/worker/reliability/ai/GeneratedInvariantReviewGate.java
@@ -1,0 +1,66 @@
+package com.tr1l.worker.reliability.ai;
+
+import com.tr1l.worker.reliability.invariant.InvariantDefinition;
+import com.tr1l.worker.reliability.support.ReliabilityResourceCatalog;
+
+import java.util.ArrayList;
+import java.util.List;
+
+// generated 후보 active 승격 gate
+public final class GeneratedInvariantReviewGate {
+    private static final int ACTIVE_PROMOTION_SCORE = 85;
+
+    public ReviewGateResult evaluate(
+            HumanReviewRecord review,
+            InvariantDefinition promoted,
+            ReliabilityResourceCatalog catalog
+    ) {
+        List<String> blockers = new ArrayList<>();
+        List<String> warnings = new ArrayList<>();
+
+        HumanReviewScoreSummary score = review.scoreSummary();
+        HumanReviewPromotionTarget target = review.promotionTarget();
+
+        if (!"approved".equalsIgnoreCase(review.reviewStatus())) {
+            blockers.add("reviewStatus 가 approved 가 아님");
+        }
+        if (score.totalScore() < ACTIVE_PROMOTION_SCORE) {
+            blockers.add("totalScore 가 active 승격 기준보다 낮음");
+        }
+        if (!score.sqlExecutable()) {
+            blockers.add("SQL 실행 가능 점수가 false");
+        }
+        if (!score.semanticallyAligned()) {
+            blockers.add("자연어 설명과 SQL 의미 일치 검토 실패");
+        }
+        if (!score.novelAgainstActive()) {
+            blockers.add("기존 active invariant 와 중복 가능성 존재");
+        }
+        if (!score.scenarioLinked() && review.reviewNotes().isEmpty()) {
+            blockers.add("scenarioLinked false 인데 보완 검토 메모가 없음");
+        }
+        if (!score.scenarioLinked() && !review.reviewNotes().isEmpty()) {
+            warnings.add("scenarioLinked false 를 사람 검토 메모로 보완");
+        }
+        if (!target.activeInvariantId().equals(promoted.id())) {
+            blockers.add("promotionTarget activeInvariantId 와 active 파일 id 불일치");
+        }
+        if (!target.checkRef().equals(promoted.checkRef())) {
+            blockers.add("promotionTarget checkRef 와 active checkRef 불일치");
+        }
+        if (!catalog.resourceExists(target.activeInvariantFile())) {
+            blockers.add("activeInvariantFile 리소스 누락");
+        }
+        if (!catalog.resourceExists(target.checkRef())) {
+            blockers.add("checkRef 리소스 누락");
+        }
+
+        return new ReviewGateResult(
+                review.generatedInvariantId(),
+                target.activeInvariantId(),
+                blockers.isEmpty(),
+                blockers,
+                warnings
+        );
+    }
+}

--- a/apps/worker/src/test/java/com/tr1l/worker/reliability/ai/HumanReviewPromotionTarget.java
+++ b/apps/worker/src/test/java/com/tr1l/worker/reliability/ai/HumanReviewPromotionTarget.java
@@ -1,0 +1,9 @@
+package com.tr1l.worker.reliability.ai;
+
+// active 승격 대상
+public record HumanReviewPromotionTarget(
+        String activeInvariantId,
+        String activeInvariantFile,
+        String checkRef
+) {
+}

--- a/apps/worker/src/test/java/com/tr1l/worker/reliability/ai/HumanReviewRecord.java
+++ b/apps/worker/src/test/java/com/tr1l/worker/reliability/ai/HumanReviewRecord.java
@@ -1,0 +1,18 @@
+package com.tr1l.worker.reliability.ai;
+
+import java.util.List;
+
+// generated 후보 사람 검토 기록
+public record HumanReviewRecord(
+        String generatedInvariantId,
+        String sourceRunName,
+        String sourceResponseId,
+        String reviewStatus,
+        String reviewedBy,
+        String reviewedAt,
+        HumanReviewScoreSummary scoreSummary,
+        String decisionReason,
+        List<String> reviewNotes,
+        HumanReviewPromotionTarget promotionTarget
+) {
+}

--- a/apps/worker/src/test/java/com/tr1l/worker/reliability/ai/HumanReviewScoreSummary.java
+++ b/apps/worker/src/test/java/com/tr1l/worker/reliability/ai/HumanReviewScoreSummary.java
@@ -1,0 +1,16 @@
+package com.tr1l.worker.reliability.ai;
+
+// 사람 검토 전 점수 요약
+public record HumanReviewScoreSummary(
+        int totalScore,
+        int formatScore,
+        int sqlExecutableScore,
+        int semanticAlignmentScore,
+        int scenarioLinkageScore,
+        int noveltyScore,
+        boolean sqlExecutable,
+        boolean semanticallyAligned,
+        boolean scenarioLinked,
+        boolean novelAgainstActive
+) {
+}

--- a/apps/worker/src/test/java/com/tr1l/worker/reliability/ai/InvariantConsistencyDecision.java
+++ b/apps/worker/src/test/java/com/tr1l/worker/reliability/ai/InvariantConsistencyDecision.java
@@ -1,0 +1,8 @@
+package com.tr1l.worker.reliability.ai;
+
+// consistency checker 판정
+public enum InvariantConsistencyDecision {
+    PASS,
+    WARN,
+    FAIL
+}

--- a/apps/worker/src/test/java/com/tr1l/worker/reliability/ai/InvariantConsistencyFinding.java
+++ b/apps/worker/src/test/java/com/tr1l/worker/reliability/ai/InvariantConsistencyFinding.java
@@ -1,0 +1,10 @@
+package com.tr1l.worker.reliability.ai;
+
+// consistency checker 단건 지적
+public record InvariantConsistencyFinding(
+        String code,
+        String severity,
+        String field,
+        String message
+) {
+}

--- a/apps/worker/src/test/java/com/tr1l/worker/reliability/ai/InvariantConsistencyReport.java
+++ b/apps/worker/src/test/java/com/tr1l/worker/reliability/ai/InvariantConsistencyReport.java
@@ -1,0 +1,13 @@
+package com.tr1l.worker.reliability.ai;
+
+import java.util.List;
+
+// consistency checker 전체 리포트
+public record InvariantConsistencyReport(
+        List<InvariantConsistencyReview> reviews,
+        int totalCandidates,
+        int passCount,
+        int warnCount,
+        int failCount
+) {
+}

--- a/apps/worker/src/test/java/com/tr1l/worker/reliability/ai/InvariantConsistencyReview.java
+++ b/apps/worker/src/test/java/com/tr1l/worker/reliability/ai/InvariantConsistencyReview.java
@@ -1,0 +1,12 @@
+package com.tr1l.worker.reliability.ai;
+
+import java.util.List;
+
+// invariant 단건 consistency 검토 결과
+public record InvariantConsistencyReview(
+        String invariantId,
+        InvariantConsistencyDecision decision,
+        List<InvariantConsistencyFinding> findings,
+        String suggestedAction
+) {
+}

--- a/apps/worker/src/test/java/com/tr1l/worker/reliability/ai/ReviewGateResult.java
+++ b/apps/worker/src/test/java/com/tr1l/worker/reliability/ai/ReviewGateResult.java
@@ -1,0 +1,13 @@
+package com.tr1l.worker.reliability.ai;
+
+import java.util.List;
+
+// review gate 판정 결과
+public record ReviewGateResult(
+        String generatedInvariantId,
+        String activeInvariantId,
+        boolean passed,
+        List<String> blockers,
+        List<String> warnings
+) {
+}

--- a/apps/worker/src/test/resources/reliability/ai/prompts/job1-invariant-consistency-checker-system.txt
+++ b/apps/worker/src/test/resources/reliability/ai/prompts/job1-invariant-consistency-checker-system.txt
@@ -1,0 +1,16 @@
+너는 분산 배치 시스템 invariant 검토자다
+
+다른 LLM 이 생성한 invariant 후보를 비판적으로 검토하라
+
+검토 기준
+1. sql_check 가 설명과 같은 의미인지 확인
+2. scope 가 always rerun_after_crash step_complete 중 적절한지 확인
+3. PROCESSING 상태가 일시적으로 허용되는 구간을 놓치지 않았는지 확인
+4. 기존 active invariant 와 의미상 중복인지 확인
+5. cross-db 검증은 SQL 단독 검증이 아니라 별도 executor 가 필요한지 표시
+
+출력 규칙
+1. JSON 객체 하나만 출력
+2. 최상위 키는 reviews totalCandidates passCount warnCount failCount 만 사용
+3. 각 review 는 invariantId decision findings suggestedAction 을 포함
+4. decision 은 PASS WARN FAIL 중 하나만 사용


### PR DESCRIPTION
## 📝작업 내용

이번 PR에서는 Job1 AI invariant 결과를 active 로 바로 올리지 않도록 review gate 를 추가했습니다

`J1S3-I7` human review 기록이 `approved` 상태이고 점수와 리소스 연결 조건을 통과할 때만 `INV-004` 승격을 인정합니다
또 generated invariant 목록을 별도 consistency checker 로 다시 검토해서 `PASS`, `WARN`, `FAIL` 로 나누는 흐름을 추가했습니다

<br/>

## 👀변경 사항

| 구분 | 변경 내용 | 이유 |
| --- | --- | --- |
| review gate | `HumanReviewRecord`, `GeneratedInvariantReviewGate` 추가 | LLM 생성 후보를 사람이 승인한 경우에만 active 승격 인정 |
| review gate | `reviewStatus`, `totalScore`, SQL 가능 여부, 의미 일치 여부, 신규성, 리소스 연결 검증 | 점수만 높고 검토 근거가 없는 후보 차단 |
| consistency checker | generated 후보를 `PASS`, `WARN`, `FAIL` 로 분류 | 같은 모델 출력에 대한 별도 검토 단계 확보 |
| consistency checker | SQL 형태, category 의미, temporal scope, active 중복, cross-db 위험 검토 | 사람이 봐야 할 위험을 구조화하기 위해 |
| prompt | `job1-invariant-consistency-checker-system.txt` 추가 | 이후 LLM reviewer 호출에 사용할 검토 기준 고정 |
| artifact | review gate 결과와 consistency report 저장 | 발표와 PR에서 실제 수치 증거를 남기기 위해 |
| test | review gate / consistency checker 계약 테스트 추가 | AI 결과 통제 흐름을 JUnit 으로 고정 |

```mermaid
flowchart LR
    A["Generated invariant 후보"] --> B["점수화 결과"]
    B --> C["Human review record"]
    C --> D{"Review Gate"}
    D -->|approved 조건 통과| E["Active 승격 허용"]
    D -->|조건 미달| F["승격 차단"]
    A --> G["Consistency Checker"]
    G --> H["PASS / WARN / FAIL 리포트"]
    H --> C

    classDef ai fill:#E8F2FF,stroke:#3B82F6,color:#0F172A
    classDef gate fill:#ECFDF5,stroke:#10B981,color:#052E16
    classDef warn fill:#FFF7ED,stroke:#F97316,color:#431407

    class A,B,G,H ai
    class C,D,E gate
    class F warn
```

### 테스트 개요

| 항목 | 내용 |
| --- | --- |
| 검증 대상 | Job1 AI invariant review gate 와 consistency checker |
| D1 입력 수치 | users `30,000`, target eligible `28,500` |
| 승격 검토 대상 | `J1S3-I7` -> `INV-004` |
| review gate 기준 | `approved`, totalScore `85` 이상, SQL 가능, 의미 일치, 신규성, active/checkRef 연결 |
| review gate 실제 결과 | passed `true`, blockers `0`, warnings `1` |
| consistency checker 입력 | sample generated candidates `4` |
| consistency checker 결과 | PASS `0`, WARN `4`, FAIL `0` |
| synthetic 실패 검증 | BAD-001 `1` 건 FAIL 처리 |
| DB 상태 검증 | 이번 PR은 DB 재실행 없이 gate 계약만 검증 |

### 테스트 결과

| 테스트 | 결과 | 수치 |
| --- | --- | --- |
| `Job1InvariantReviewGateContractTest` | PASS | 2 / 2 |
| `Job1InvariantConsistencyCheckerContractTest` | PASS | 3 / 3 |
| `Job1InvariantHumanReviewContractTest` | PASS | 1 / 1 |
| `Job1AiInvariantScoringContractTest` | PASS | 1 / 1 |
| 전체 | PASS | 7 / 7 |

### 참고 artifact

| 구분 | 경로 |
| --- | --- |
| review gate 결과 | `apps/worker/build/job1-ai-invariant-results/review-gate/J1S3-I7-review-gate-result.json` |
| consistency checker 결과 | `apps/worker/build/job1-ai-invariant-results/consistency-checker/job1-invariant-consistency-report.json` |
| JUnit 결과 | `apps/worker/build/test-results/test/TEST-com.tr1l.worker.reliability.Job1InvariantReviewGateContractTest.xml` |
| JUnit 결과 | `apps/worker/build/test-results/test/TEST-com.tr1l.worker.reliability.Job1InvariantConsistencyCheckerContractTest.xml` |

<br/>

## 🎫 Jira Ticket
- Jira Ticket: TR1L-159

<br/>

## #️⃣관련 이슈

- closes #348
