### PR TITLE
[TR1L-160] feat: Scenario catalog와 invariant coverage matrix 추가

### DIFF
--- a/apps/worker/src/test/java/com/tr1l/worker/reliability/Job1InvariantCoverageMatrixContractTest.java
+++ b/apps/worker/src/test/java/com/tr1l/worker/reliability/Job1InvariantCoverageMatrixContractTest.java
@@ -1,0 +1,86 @@
+package com.tr1l.worker.reliability;
+
+import com.tr1l.worker.reliability.coverage.InvariantCoverageMarkdownRenderer;
+import com.tr1l.worker.reliability.coverage.InvariantCoverageMatrix;
+import com.tr1l.worker.reliability.coverage.InvariantCoverageMatrixGenerator;
+import com.tr1l.worker.reliability.coverage.InvariantCoverageRow;
+import com.tr1l.worker.reliability.support.ReliabilityObjectMappers;
+import com.tr1l.worker.reliability.support.ReliabilityResourceCatalog;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+// Job1 시나리오와 active invariant 연결 지도
+class Job1InvariantCoverageMatrixContractTest {
+    private final ReliabilityResourceCatalog catalog = new ReliabilityResourceCatalog();
+    private final InvariantCoverageMatrixGenerator generator = new InvariantCoverageMatrixGenerator();
+    private final InvariantCoverageMarkdownRenderer markdownRenderer = new InvariantCoverageMarkdownRenderer();
+
+    @Test
+    @DisplayName("Job1 시나리오와 active invariant coverage matrix 를 생성하는지 보기")
+    void job1ScenariosShouldGenerateInvariantCoverageMatrix() throws Exception {
+        InvariantCoverageMatrix matrix = generator.generate(
+                catalog.loadScenarios(),
+                catalog.loadActiveInvariants()
+        );
+
+        Path outputDir = Paths.get(
+                "build",
+                "job1-reliability-results",
+                "coverage-matrix"
+        );
+        Files.createDirectories(outputDir);
+
+        Path jsonPath = outputDir.resolve("job1-invariant-coverage-matrix.json");
+        Path markdownPath = outputDir.resolve("job1-invariant-coverage-matrix.md");
+
+        Files.writeString(
+                jsonPath,
+                ReliabilityObjectMappers.json().writeValueAsString(matrix),
+                StandardCharsets.UTF_8
+        );
+        Files.writeString(
+                markdownPath,
+                markdownRenderer.render(matrix),
+                StandardCharsets.UTF_8
+        );
+
+        assertThat(matrix.scenarioIds())
+                .contains("S-001", "S-001R", "S-003", "S-003R");
+        assertThat(matrix.rows())
+                .hasSize(catalog.loadActiveInvariants().size());
+        assertThat(matrix.uncoveredInvariantIds()).isEmpty();
+        assertThat(matrix.scenariosWithoutInvariants()).isEmpty();
+        assertThat(matrix.unknownInvariantReferences()).isEmpty();
+
+        assertThat(row(matrix, "INV-001").coveredScenarioIds())
+                .contains("S-001", "S-001R", "S-003", "S-003R");
+        assertThat(row(matrix, "INV-002").coveredScenarioIds())
+                .contains("S-001", "S-001R", "S-003R")
+                .doesNotContain("S-003");
+        assertThat(row(matrix, "INV-003").coveredScenarioIds())
+                .contains("S-001", "S-001R", "S-003R")
+                .doesNotContain("S-003");
+
+        assertThat(jsonPath).exists();
+        assertThat(markdownPath).exists();
+        assertThat(Files.readString(markdownPath))
+                .contains("| invariant | category |")
+                .contains("INV-001")
+                .contains("S-001")
+                .contains("S-003R");
+    }
+
+    private InvariantCoverageRow row(InvariantCoverageMatrix matrix, String invariantId) {
+        return matrix.rows().stream()
+                .filter(row -> invariantId.equals(row.invariantId()))
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException("Coverage row not found: " + invariantId));
+    }
+}

--- a/apps/worker/src/test/java/com/tr1l/worker/reliability/coverage/InvariantCoverageMarkdownRenderer.java
+++ b/apps/worker/src/test/java/com/tr1l/worker/reliability/coverage/InvariantCoverageMarkdownRenderer.java
@@ -1,0 +1,86 @@
+package com.tr1l.worker.reliability.coverage;
+
+// 블로그와 PR에 붙일 coverage matrix 표 생성
+public final class InvariantCoverageMarkdownRenderer {
+    public String render(InvariantCoverageMatrix matrix) {
+        StringBuilder builder = new StringBuilder();
+
+        builder.append("# Job1 Invariant Coverage Matrix\n\n");
+        builder.append("- scenario count: ").append(matrix.scenarioCount()).append("\n");
+        builder.append("- invariant count: ").append(matrix.invariantCount()).append("\n");
+        builder.append("- uncovered invariants: ").append(matrix.uncoveredInvariantIds().size()).append("\n");
+        builder.append("- invalid references: ").append(matrix.unknownInvariantReferences().size()).append("\n\n");
+
+        appendTable(builder, matrix);
+        appendWarnings(builder, matrix);
+
+        return builder.toString();
+    }
+
+    private void appendTable(StringBuilder builder, InvariantCoverageMatrix matrix) {
+        builder.append("| invariant | category |");
+
+        for (String scenarioId : matrix.scenarioIds()) {
+            builder.append(" ").append(scenarioId).append(" |");
+        }
+
+        builder.append(" coverage |\n");
+        builder.append("| --- | --- |");
+
+        for (int i = 0; i < matrix.scenarioIds().size(); i++) {
+            builder.append(" --- |");
+        }
+
+        builder.append(" ---: |\n");
+
+        for (InvariantCoverageRow row : matrix.rows()) {
+            builder.append("| ")
+                    .append(row.invariantId())
+                    .append(" ")
+                    .append(row.title())
+                    .append(" | ")
+                    .append(row.category())
+                    .append(" |");
+
+            for (String scenarioId : matrix.scenarioIds()) {
+                builder.append(" ")
+                        .append(row.coveredBy(scenarioId) ? "O" : "-")
+                        .append(" |");
+            }
+
+            builder.append(" ")
+                    .append(row.coverageCount())
+                    .append("/")
+                    .append(matrix.scenarioCount())
+                    .append(" |\n");
+        }
+    }
+
+    private void appendWarnings(StringBuilder builder, InvariantCoverageMatrix matrix) {
+        if (matrix.uncoveredInvariantIds().isEmpty()
+                && matrix.scenariosWithoutInvariants().isEmpty()
+                && matrix.unknownInvariantReferences().isEmpty()) {
+            return;
+        }
+
+        builder.append("\n## Review Required\n\n");
+
+        if (!matrix.uncoveredInvariantIds().isEmpty()) {
+            builder.append("- uncovered invariants: ")
+                    .append(matrix.uncoveredInvariantIds())
+                    .append("\n");
+        }
+
+        if (!matrix.scenariosWithoutInvariants().isEmpty()) {
+            builder.append("- scenarios without invariants: ")
+                    .append(matrix.scenariosWithoutInvariants())
+                    .append("\n");
+        }
+
+        if (!matrix.unknownInvariantReferences().isEmpty()) {
+            builder.append("- unknown invariant references: ")
+                    .append(matrix.unknownInvariantReferences())
+                    .append("\n");
+        }
+    }
+}

--- a/apps/worker/src/test/java/com/tr1l/worker/reliability/coverage/InvariantCoverageMatrix.java
+++ b/apps/worker/src/test/java/com/tr1l/worker/reliability/coverage/InvariantCoverageMatrix.java
@@ -1,0 +1,28 @@
+package com.tr1l.worker.reliability.coverage;
+
+import java.util.List;
+
+// 시나리오와 불변 조건 연결 결과
+public record InvariantCoverageMatrix(
+        List<String> scenarioIds,
+        int scenarioCount,
+        int invariantCount,
+        List<InvariantCoverageRow> rows,
+        List<String> uncoveredInvariantIds,
+        List<String> scenariosWithoutInvariants,
+        List<UnknownInvariantReference> unknownInvariantReferences
+) {
+    public boolean hasUncoveredInvariant() {
+        return !uncoveredInvariantIds.isEmpty();
+    }
+
+    public boolean hasInvalidReference() {
+        return !unknownInvariantReferences.isEmpty();
+    }
+
+    public record UnknownInvariantReference(
+            String scenarioId,
+            String invariantId
+    ) {
+    }
+}

--- a/apps/worker/src/test/java/com/tr1l/worker/reliability/coverage/InvariantCoverageMatrixGenerator.java
+++ b/apps/worker/src/test/java/com/tr1l/worker/reliability/coverage/InvariantCoverageMatrixGenerator.java
@@ -1,0 +1,95 @@
+package com.tr1l.worker.reliability.coverage;
+
+import com.tr1l.worker.reliability.invariant.InvariantDefinition;
+import com.tr1l.worker.reliability.scenario.Job1ScenarioDefinition;
+
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+// 시나리오 리소스와 active invariant 연결 계산
+public final class InvariantCoverageMatrixGenerator {
+    public InvariantCoverageMatrix generate(
+            List<Job1ScenarioDefinition> scenarios,
+            List<InvariantDefinition> activeInvariants
+    ) {
+        List<Job1ScenarioDefinition> sortedScenarios = scenarios.stream()
+                .sorted(Comparator.comparing(Job1ScenarioDefinition::id))
+                .toList();
+
+        List<InvariantDefinition> sortedInvariants = activeInvariants.stream()
+                .sorted(Comparator.comparing(InvariantDefinition::id))
+                .toList();
+
+        Set<String> activeInvariantIds = sortedInvariants.stream()
+                .map(InvariantDefinition::id)
+                .collect(Collectors.toSet());
+
+        List<String> scenarioIds = sortedScenarios.stream()
+                .map(Job1ScenarioDefinition::id)
+                .toList();
+
+        List<InvariantCoverageRow> rows = sortedInvariants.stream()
+                .map(invariant -> toRow(invariant, sortedScenarios))
+                .toList();
+
+        List<String> uncoveredInvariantIds = rows.stream()
+                .filter(row -> row.coverageCount() == 0)
+                .map(InvariantCoverageRow::invariantId)
+                .toList();
+
+        List<String> scenariosWithoutInvariants = sortedScenarios.stream()
+                .filter(scenario -> invariantIdsOf(scenario).isEmpty())
+                .map(Job1ScenarioDefinition::id)
+                .toList();
+
+        List<InvariantCoverageMatrix.UnknownInvariantReference> unknownReferences = sortedScenarios.stream()
+                .flatMap(scenario -> invariantIdsOf(scenario).stream()
+                        .filter(invariantId -> !activeInvariantIds.contains(invariantId))
+                        .map(invariantId -> new InvariantCoverageMatrix.UnknownInvariantReference(
+                                scenario.id(),
+                                invariantId
+                        )))
+                .toList();
+
+        return new InvariantCoverageMatrix(
+                scenarioIds,
+                sortedScenarios.size(),
+                sortedInvariants.size(),
+                rows,
+                uncoveredInvariantIds,
+                scenariosWithoutInvariants,
+                unknownReferences
+        );
+    }
+
+    // 불변 조건 하나의 coverage row 생성
+    private InvariantCoverageRow toRow(
+            InvariantDefinition invariant,
+            List<Job1ScenarioDefinition> scenarios
+    ) {
+        List<String> coveredScenarioIds = scenarios.stream()
+                .filter(scenario -> invariantIdsOf(scenario).contains(invariant.id()))
+                .map(Job1ScenarioDefinition::id)
+                .toList();
+
+        return new InvariantCoverageRow(
+                invariant.id(),
+                invariant.title(),
+                invariant.category(),
+                invariant.scope(),
+                coveredScenarioIds,
+                coveredScenarioIds.size()
+        );
+    }
+
+    // 시나리오에 연결된 invariant id 목록 추출
+    private Set<String> invariantIdsOf(Job1ScenarioDefinition scenario) {
+        if (scenario.validate() == null || scenario.validate().invariants() == null) {
+            return Set.of();
+        }
+        return new HashSet<>(scenario.validate().invariants());
+    }
+}

--- a/apps/worker/src/test/java/com/tr1l/worker/reliability/coverage/InvariantCoverageRow.java
+++ b/apps/worker/src/test/java/com/tr1l/worker/reliability/coverage/InvariantCoverageRow.java
@@ -1,0 +1,17 @@
+package com.tr1l.worker.reliability.coverage;
+
+import java.util.List;
+
+// 불변 조건 하나가 어떤 시나리오에서 검증되는지 표현
+public record InvariantCoverageRow(
+        String invariantId,
+        String title,
+        String category,
+        String scope,
+        List<String> coveredScenarioIds,
+        int coverageCount
+) {
+    public boolean coveredBy(String scenarioId) {
+        return coveredScenarioIds.contains(scenarioId);
+    }
+}

--- a/apps/worker/src/test/java/com/tr1l/worker/reliability/support/ReliabilityResourceCatalog.java
+++ b/apps/worker/src/test/java/com/tr1l/worker/reliability/support/ReliabilityResourceCatalog.java
@@ -30,25 +30,16 @@ public final class ReliabilityResourceCatalog {
         return readJsonDirectory("classpath*:reliability/invariants/active/*.json", InvariantDefinition.class);
     }
 
+    public List<Job1ScenarioDefinition> loadScenarios() {
+        return readYamlDirectory("classpath*:reliability/scenarios/*.yml", Job1ScenarioDefinition.class);
+    }
+
     public Job1ScenarioDefinition loadScenario(String scenarioId) {
-        try {
-            Resource[] resources = resolver.getResources("classpath*:reliability/scenarios/*.yml");
-            return Arrays.stream(resources)
-                    // 시나리오 id 기준 매칭
-                    // 접두어 혼선 방지
-                    .map(resource -> {
-                        try {
-                            return ReliabilityObjectMappers.yaml().readValue(resource.getInputStream(), Job1ScenarioDefinition.class);
-                        } catch (IOException e) {
-                            throw new IllegalStateException("Failed to read scenario resource: " + resource, e);
-                        }
-                    })
-                    .filter(definition -> scenarioId.equals(definition.id()))
-                    .findFirst()
-                    .orElseThrow(() -> new IllegalStateException("Scenario resource not found for id: " + scenarioId));
-        } catch (IOException e) {
-            throw new IllegalStateException("Failed to resolve scenario resources", e);
-        }
+        return loadScenarios().stream()
+                // 시나리오 id 기준 단건 조회
+                .filter(definition -> scenarioId.equals(definition.id()))
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException("Scenario resource not found for id: " + scenarioId));
     }
 
     public String loadCheckText(String classpathLocation) {
@@ -74,6 +65,31 @@ public final class ReliabilityResourceCatalog {
                     .map(resource -> {
                         try {
                             return ReliabilityObjectMappers.json().readValue(resource.getInputStream(), type);
+                        } catch (IOException e) {
+                            throw new IllegalStateException("Failed to read resource " + resource, e);
+                        }
+                    })
+                    .toList();
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to resolve resources: " + pattern, e);
+        }
+    }
+
+    // 특정 classpath 패턴의 YAML 파일 목록 적재
+    private <T> List<T> readYamlDirectory(String pattern, Class<T> type) {
+        try {
+            Resource[] resources = resolver.getResources(pattern);
+            return Arrays.stream(resources)
+                    .sorted(Comparator.comparing(resource -> {
+                        try {
+                            return resource.getFilename();
+                        } catch (Exception e) {
+                            return "";
+                        }
+                    }))
+                    .map(resource -> {
+                        try {
+                            return ReliabilityObjectMappers.yaml().readValue(resource.getInputStream(), type);
                         } catch (IOException e) {
                             throw new IllegalStateException("Failed to read resource " + resource, e);
                         }


### PR DESCRIPTION
## 📝작업 내용

Job1 reliability 시나리오와 active invariant 연결 상태를 coverage matrix 로 자동 생성하도록 추가했음

기존 `S-001`, `S-001R`, `S-003`, `S-003R` 시나리오가 어떤 invariant 를 검증하는지 JSON/Markdown artifact 로 남기도록 구성했음
새 fault scenario 를 추가하기 전 현재 검증 범위를 먼저 눈으로 확인할 수 있게 정리했음

<br/>

## 👀변경 사항

| 구분 | 변경 내용 | 이유 |
| --- | --- | --- |
| catalog | `loadScenarios()` 추가 | 전체 scenario YAML 을 한 번에 읽기 위함 |
| coverage model | `InvariantCoverageMatrix`, `InvariantCoverageRow` 추가 | scenario 와 invariant 연결 결과를 구조화 |
| coverage generator | `InvariantCoverageMatrixGenerator` 추가 | `scenario.validate.invariants` 기준 matrix 계산 |
| markdown renderer | `InvariantCoverageMarkdownRenderer` 추가 | PR 과 블로그에 붙일 표 자동 생성 |
| test | `Job1InvariantCoverageMatrixContractTest` 추가 | matrix 생성과 artifact 저장 검증 |

```mermaid
flowchart LR
    A["reliability/scenarios/*.yml"] --> C["Coverage Matrix Generator"]
    B["reliability/invariants/active/*.json"] --> C
    C --> D["scenario x invariant 매핑 계산"]
    D --> E["coverage matrix json"]
    D --> F["coverage matrix markdown"]
    E --> G["JUnit contract test"]
    F --> H["PR / 블로그 첨부"]

    classDef source fill:#E8F3FF,stroke:#2563EB,color:#0F172A
    classDef calc fill:#FFF7ED,stroke:#EA580C,color:#431407
    classDef artifact fill:#F5F3FF,stroke:#7C3AED,color:#2E1065
    classDef test fill:#ECFDF5,stroke:#059669,color:#022C22

    class A,B source
    class C,D calc
    class E,F artifact
    class G,H test
```

### 테스트 개요

| 항목 | 내용 |
| --- | --- |
| 검증 대상 | Job1 scenario 와 active invariant 연결 상태 |
| scenario 입력 | `S-001`, `S-001R`, `S-003`, `S-003R` |
| active invariant 입력 | `INV-001`, `INV-002`, `INV-003` |
| 생성 artifact | JSON `1`건, Markdown `1`건 |
| 검증 방식 | scenario YAML 과 active invariant JSON 만 읽는 resource contract test |
| DB 의존성 | 없음 |

### Coverage Matrix 결과

| invariant | category | S-001 | S-001R | S-003 | S-003R | coverage |
| --- | --- | --- | --- | --- | --- | ---: |
| INV-001 No duplicate billing_work | state_consistency | O | O | O | O | 4/4 |
| INV-002 No stale PROCESSING after rerun | temporal | O | O | - | O | 3/4 |
| INV-003 Calculated work has Mongo snapshot | referential | O | O | - | O | 3/4 |

### 테스트 결과

| 테스트 | 결과 | 수치 |
| --- | --- | --- |
| `Job1InvariantCoverageMatrixContractTest` | PASS | 1 / 1 |
| `Job1ReliabilityResourceContractTest` | PASS | 4 / 4 |
| 전체 | PASS | 5 / 5 |

### 참고 artifact

| 구분 | 경로 |
| --- | --- |
| coverage matrix markdown | `apps/worker/build/job1-reliability-results/coverage-matrix/job1-invariant-coverage-matrix.md` |
| coverage matrix json | `apps/worker/build/job1-reliability-results/coverage-matrix/job1-invariant-coverage-matrix.json` |
| JUnit 결과 | `apps/worker/build/test-results/test/TEST-com.tr1l.worker.reliability.Job1InvariantCoverageMatrixContractTest.xml` |

<br/>

## 🎫 Jira Ticket
- Jira Ticket: TR1L-160

<br/>

## #️⃣관련 이슈

- closes #350
